### PR TITLE
skip empty lines in cal_threhold.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-linux:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["ubuntu-20.04"]
-        python-version: ["3.8", "3.9"]
-      max-parallel: 5
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -28,9 +23,9 @@ jobs:
         micromamba run -n sstar pytest --cov=. --cov-report term-missing
         micromamba run -n sstar coverage xml
     - name: upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
           name: codecov-umbrella
           fail_ci_if_error: true
           env_vars: OS,PYTHON
-          token: d257164e-ffda-43ba-b37b-f33b5dde0f34
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/sstar/cal_threshold.py
+++ b/sstar/cal_threshold.py
@@ -201,8 +201,10 @@ def _read_recomb_map(recomb_map_file):
     """
     recomb_map = dict()
     with open(recomb_map_file, 'r') as f:
-        for line in f.readlines():
+        for line in f:
             line = line.rstrip()
+            if not line.strip():
+                continue
             element = line.split("\t")
             key = element[0]+":"+element[1]+"-"+element[2]
             if key not in recomb_map.keys(): recomb_map[key] = float(element[3])


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Skip empty lines in the recombination map reader to avoid processing blank lines