### PR TITLE
Add official repository details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,8 @@
 [![codecov](https://codecov.io/gh/xin-huang/sstar/branch/main/graph/badge.svg?token=71r46xjWnU)](https://codecov.io/gh/xin-huang/sstar)
 [![Documentation Status](https://readthedocs.org/projects/sstar/badge/?version=latest)](https://sstar.readthedocs.io/en/latest/?badge=latest)
 
+The **OFFICIAL** repository: https://github.com/xin-huang/sstar
+
+Contributions, bug reports, and feature requests should be directed to [the official repository](https://github.com/xin-huang/sstar). If you are viewing a fork, please note that it may diverge from upstream and is not maintained by the official maintainers. Please refer to **the official repository** for current releases, documentation, and contribution guidelines. When citing this software, cite **the official repository**, and use **official releases** for production or reproducible analyses.
+
 The manual can be found [here](https://xin-huang.github.io/sstar).


### PR DESCRIPTION
Added information about the official repository and contribution guidelines.

## Summary by Sourcery

Document the official upstream GitHub repository and clarify contribution and usage guidance.

Documentation:
- Add a note identifying the official GitHub repository and directing contributions, issues, and feature requests there.
- Clarify that forks may diverge from upstream and that official releases and documentation live in the main repository.