### PR TITLE
Add `--keep-simulated-data` flag to `quantile` and clean up intermediate simulated files by default

### DIFF
--- a/sstar/__main__.py
+++ b/sstar/__main__.py
@@ -64,6 +64,7 @@ def _run_quantile(args):
         thread=args.thread,
         seeds=args.seeds,
         is_phased=args.phased,
+        keep_simulated_data=args.keep_simulated_data,
     )
 
 
@@ -210,6 +211,7 @@ def _s_star_cli_parser():
     )
     parser.add_argument("--output-dir", type=str, dest="output_dir", required=True)
     parser.add_argument("--thread", type=int, default=1)
+    parser.add_argument("--keep-simulated-data", action="store_true")
     parser.set_defaults(runner=_run_quantile)
 
     # threshold

--- a/sstar/get_quantile.py
+++ b/sstar/get_quantile.py
@@ -16,6 +16,7 @@
 import os
 import demes
 import glob
+import shutil
 import subprocess
 import numpy as np
 import pandas as pd
@@ -88,6 +89,7 @@ def get_quantile(
     thread,
     seeds,
     is_phased: bool = False,
+    keep_simulated_data: bool = False,
 ):
     """
     Description:
@@ -112,6 +114,7 @@ def get_quantile(
         thread int: Number of threads.
         seeds: list: Three random seed numbers used in ms simulation.
         is_phased bool: Whether to run sstar score with --phased.
+        keep_simulated_data bool: Whether to keep intermediate simulation files.
     """
     if seeds is not None:
         np.random.seed(np.sum(seeds))
@@ -119,7 +122,7 @@ def get_quantile(
     if os.path.exists(output_dir) is False:
         os.makedirs(output_dir, exist_ok=True)  # no subprocess mkdir
     _generate_mut_rec_combination(N0, nreps, mut_rate, rec_rate, seq_len, output_dir)
-    _run_ms_simulation(
+    simulated_snp_dirs = _run_ms_simulation(
         model,
         ms_dir,
         N0,
@@ -137,6 +140,8 @@ def get_quantile(
         is_phased,
     )
     _summary(output_dir, rec_rate)
+    if not keep_simulated_data:
+        _cleanup_simulated_data(output_dir, simulated_snp_dirs)
 
 
 def _generate_mut_rec_combination(N0, nreps, mut_rate, rec_rate, seq_len, output_dir):
@@ -287,6 +292,8 @@ def _run_ms_simulation(
     finally:
         for worker in workers:
             worker.join()
+
+    return [str(snp_num) for snp_num in snp_num_list]
 
 
 def _run_ms_simulation_worker(
@@ -509,3 +516,35 @@ def _summary(output_dir, rec_rate):
     df.sort_values(by=["SNP_num", "quantile"]).to_csv(
         f"{output_dir}/quantile.summary.txt", sep="\t", index=False
     )
+
+
+def _cleanup_simulated_data(output_dir, simulated_snp_dirs):
+    """
+    Description:
+        Remove intermediate files generated during ms simulations.
+
+    Arguments:
+        output_dir str: Name of the output directory.
+        simulated_snp_dirs list[str]: SNP-number directories created by this run.
+    """
+    generated_files = {"rates.combination", "sim.ref.list", "sim.tgt.list"}
+    simulated_dir_required_files = {
+        "sim.ms",
+        "sim.vcf",
+        "sim.score",
+        "sim.quantile",
+        "run_ms.sh",
+    }
+
+    for filename in generated_files:
+        path = os.path.join(output_dir, filename)
+        if os.path.isfile(path):
+            os.remove(path)
+
+    for dirname in simulated_snp_dirs:
+        subdir = os.path.join(output_dir, dirname)
+        if not os.path.isdir(subdir):
+            continue
+        existing_files = set(os.listdir(subdir))
+        if simulated_dir_required_files.issubset(existing_files):
+            shutil.rmtree(subdir)

--- a/tests/test_get_quantile.py
+++ b/tests/test_get_quantile.py
@@ -23,6 +23,7 @@ import pytest
 from sstar.get_quantile import (
     get_quantile,
     _cal_quantile,
+    _cleanup_simulated_data,
     _summary,
     _ms2vcf,
     _run_ms_simulation,
@@ -141,6 +142,50 @@ def test_summary_aggregates_quantiles(tmp_path):
     assert "log(local_recomb_rate)" in out.columns
     assert set(out["SNP_num"]) == {10, 20}
     assert np.isclose(out["log(local_recomb_rate)"].iloc[0], -8.0)
+
+
+def test_cleanup_simulated_data_keeps_summary(tmp_path):
+    (tmp_path / "quantile.summary.txt").write_text("x\n")
+    (tmp_path / "rates.combination").write_text("y\n")
+    (tmp_path / "sim.ref.list").write_text("ref\n")
+    (tmp_path / "sim.tgt.list").write_text("tgt\n")
+    (tmp_path / "user.notes.txt").write_text("keep me\n")
+
+    simulated_subdir = tmp_path / "10"
+    simulated_subdir.mkdir()
+    for filename in ["sim.ms", "sim.vcf", "sim.score", "sim.quantile", "run_ms.sh"]:
+        (simulated_subdir / filename).write_text("z\n")
+
+    unrelated_subdir = tmp_path / "analysis"
+    unrelated_subdir.mkdir()
+    (unrelated_subdir / "result.txt").write_text("keep directory\n")
+
+    _cleanup_simulated_data(str(tmp_path), simulated_snp_dirs=["10"])
+
+    assert (tmp_path / "quantile.summary.txt").exists()
+    assert not (tmp_path / "rates.combination").exists()
+    assert not (tmp_path / "sim.ref.list").exists()
+    assert not (tmp_path / "sim.tgt.list").exists()
+    assert not simulated_subdir.exists()
+    assert (tmp_path / "user.notes.txt").exists()
+    assert unrelated_subdir.exists()
+
+
+def test_cleanup_simulated_data_only_removes_tracked_dirs(tmp_path):
+    tracked_subdir = tmp_path / "10"
+    tracked_subdir.mkdir()
+    for filename in ["sim.ms", "sim.vcf", "sim.score", "sim.quantile", "run_ms.sh"]:
+        (tracked_subdir / filename).write_text("z\n")
+
+    untracked_subdir = tmp_path / "20"
+    untracked_subdir.mkdir()
+    for filename in ["sim.ms", "sim.vcf", "sim.score", "sim.quantile", "run_ms.sh"]:
+        (untracked_subdir / filename).write_text("z\n")
+
+    _cleanup_simulated_data(str(tmp_path), simulated_snp_dirs=["10"])
+
+    assert not tracked_subdir.exists()
+    assert untracked_subdir.exists()
 
 
 def test_ms2vcf_roundtrip(tmp_path):

--- a/tests/test_main_.py
+++ b/tests/test_main_.py
@@ -96,6 +96,51 @@ def test_quantile_subcommand_calls_runner():
             ]
         )
         mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args.keep_simulated_data is False
+
+
+def test_quantile_subcommand_keep_simulated_data_flag():
+    with patch("sstar.__main__._run_quantile") as mock_run:
+        main(
+            [
+                "quantile",
+                "--model",
+                "model.yaml",
+                "--ms-dir",
+                "/tmp/ms",
+                "--N0",
+                "10000",
+                "--nsamp",
+                "20",
+                "--nreps",
+                "10",
+                "--ref-index",
+                "1",
+                "--ref-size",
+                "10",
+                "--tgt-index",
+                "2",
+                "--tgt-size",
+                "10",
+                "--mut-rate",
+                "1e-8",
+                "--rec-rate",
+                "1e-8",
+                "--seq-len",
+                "100000",
+                "--snp-num-range",
+                "50",
+                "200",
+                "10",
+                "--output-dir",
+                "quant_out",
+                "--keep-simulated-data",
+            ]
+        )
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args.keep_simulated_data is True
 
 
 def test_threshold_subcommand_calls_runner():


### PR DESCRIPTION
### Motivation
- Users running `sstar quantile` produce many intermediate simulated files (ms, vcf, score, per-SNP subdirs) that should be removable by default to avoid cluttering output directories. 
- Provide an explicit opt-out so users can retain intermediate simulation artifacts when needed via a clear CLI flag.

### Description
- Add a new CLI option `--keep-simulated-data` to the `quantile` subcommand, exposed in the parser and forwarded to `get_quantile` as `keep_simulated_data`.
- Extend `get_quantile(...)` with the `keep_simulated_data: bool = False` parameter and call a cleanup helper after `quantile.summary.txt` is produced when the flag is not set.
- Implement `_cleanup_simulated_data(output_dir)` which preserves `quantile.summary.txt` and removes other generated files and subdirectories (e.g. `rates.combination`, per-SNP folders and their `sim.*` files).
- Update tests to assert the new CLI option's presence and behavior and add a unit test that verifies the cleanup helper retains the summary file while removing other simulated artifacts.

### Testing
- Updated unit tests in `tests/test_main_.py` and `tests/test_get_quantile.py` to cover the new flag and the cleanup helper; these tests were added/modified in this change.
- Ran `pytest -q tests/test_main_.py tests/test_get_quantile.py`, but collection failed in the current environment with `ModuleNotFoundError: No module named 'sstar'` and `ModuleNotFoundError: No module named 'numpy'`, so the test suite could not complete here (failure is environmental, not logic-related).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c9ca44dc832c9d9c362755d0c913)

## Summary by Sourcery

Add an option to retain intermediate simulation artifacts from the quantile workflow while cleaning them up by default after summary generation.

New Features:
- Introduce a --keep-simulated-data CLI flag for the quantile subcommand to allow retaining intermediate simulation files.

Enhancements:
- Extend get_quantile with a keep_simulated_data parameter and perform post-run cleanup of generated simulation files when not requested to be kept.
- Add a helper to remove known intermediate simulation files and directories while preserving the quantile summary and unrelated user outputs.

Tests:
- Expand quantile CLI tests to cover the new keep-simulated-data flag behavior.
- Add a unit test validating that simulated data cleanup preserves the quantile summary and user files while removing simulation artifacts.