### PR TITLE
Replace remaining gaishi references with sstar

### DIFF
--- a/sstar/configs/global_config.py
+++ b/sstar/configs/global_config.py
@@ -27,6 +27,11 @@ from sstar.configs import GenotypeMatrixPreprocessConfig
 
 SimulationConfigUnion = Annotated[
     Union[FeatureVectorSimulationConfig, GenotypeMatrixSimulationConfig],
+]
+
+class GlobalConfig(BaseModel):
+    """
+    Top-level config for running sstar
     Field(discriminator="sim_type"),
 ]
 

--- a/sstar/configs/global_config.py
+++ b/sstar/configs/global_config.py
@@ -19,11 +19,11 @@
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Annotated, Union
-from gaishi.configs import ModelConfig
-from gaishi.configs import FeatureVectorSimulationConfig
-from gaishi.configs import GenotypeMatrixSimulationConfig
-from gaishi.configs import FeatureVectorPreprocessConfig
-from gaishi.configs import GenotypeMatrixPreprocessConfig
+from sstar.configs import ModelConfig
+from sstar.configs import FeatureVectorSimulationConfig
+from sstar.configs import GenotypeMatrixSimulationConfig
+from sstar.configs import FeatureVectorPreprocessConfig
+from sstar.configs import GenotypeMatrixPreprocessConfig
 
 SimulationConfigUnion = Annotated[
     Union[FeatureVectorSimulationConfig, GenotypeMatrixSimulationConfig],
@@ -38,7 +38,7 @@ PreprocessConfigUnion = Annotated[
 
 class GlobalConfig(BaseModel):
     """
-    Top-level config for runing gaishi
+    Top-level config for runing sstar
 
     - training: simulation + model details.
     - infer: preprocess + model details.

--- a/sstar/configs/model_config.py
+++ b/sstar/configs/model_config.py
@@ -38,7 +38,7 @@ class LrParams(BaseModel):
     @model_validator(mode="after")
     def validate_known_keys(self) -> "LrParams":
         """
-        Validate keys against LogisticRegression signature plus gaishi-specific keys.
+        Validate keys against LogisticRegression signature plus sstar-specific keys.
         """
         allowed_keys = set(inspect.signature(LogisticRegression).parameters)
         allowed_keys.add("is_scaled")
@@ -61,7 +61,7 @@ class EtcParams(BaseModel):
     @model_validator(mode="after")
     def validate_known_keys(self) -> "EtcParams":
         """
-        Validate keys against ExtraTreesClassifier signature plus gaishi-specific keys.
+        Validate keys against ExtraTreesClassifier signature plus sstar-specific keys.
         """
         allowed_keys = set(inspect.signature(ExtraTreesClassifier).parameters)
         allowed_keys.add("is_scaled")

--- a/sstar/generators/random_number_generator.py
+++ b/sstar/generators/random_number_generator.py
@@ -18,7 +18,7 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import numpy as np
-from gaishi.generators import GenericGenerator
+from sstar.generators import GenericGenerator
 
 
 class RandomNumberGenerator(GenericGenerator):

--- a/sstar/generators/window_data_generator.py
+++ b/sstar/generators/window_data_generator.py
@@ -18,8 +18,8 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import numpy as np
-from gaishi.utils import read_data, split_genome
-from gaishi.generators import GenericGenerator
+from sstar.utils import read_data, split_genome
+from sstar.generators import GenericGenerator
 
 
 class WindowDataGenerator(GenericGenerator):

--- a/sstar/infer.py
+++ b/sstar/infer.py
@@ -18,11 +18,11 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import yaml
-from gaishi.configs import GlobalConfig
-from gaishi.registries.model_registry import MODEL_REGISTRY
-from gaishi.preprocess import preprocess_feature_vectors
-from gaishi.preprocess import preprocess_genotype_matrices
-from gaishi.utils import UniqueKeyLoader, filter_model_params_for_method
+from sstar.configs import GlobalConfig
+from sstar.registries.model_registry import MODEL_REGISTRY
+from sstar.preprocess import preprocess_feature_vectors
+from sstar.preprocess import preprocess_genotype_matrices
+from sstar.utils import UniqueKeyLoader, filter_model_params_for_method
 
 
 def infer(

--- a/sstar/multiprocessing/mp_manager.py
+++ b/sstar/multiprocessing/mp_manager.py
@@ -19,7 +19,7 @@
 
 import multiprocessing, queue, time
 import numpy as np
-from gaishi.generators import GenericGenerator
+from sstar.generators import GenericGenerator
 from multiprocessing import current_process, Manager, Process, Queue
 from threading import Thread
 

--- a/sstar/preprocess.py
+++ b/sstar/preprocess.py
@@ -19,13 +19,13 @@
 
 import os, multiprocessing, yaml
 import pandas as pd
-from gaishi.utils import parse_ind_file, initialize_h5, write_h5
-from gaishi.utils import create_sample_name_list
-from gaishi.multiprocessing import mp_manager
-from gaishi.generators import WindowDataGenerator
-from gaishi.generators import PolymorphismDataGenerator
-from gaishi.preprocessors import FeatureVectorPreprocessor
-from gaishi.preprocessors import GenotypeMatrixPreprocessor
+from sstar.utils import parse_ind_file, initialize_h5, write_h5
+from sstar.utils import create_sample_name_list
+from sstar.multiprocessing import mp_manager
+from sstar.generators import WindowDataGenerator
+from sstar.generators import PolymorphismDataGenerator
+from sstar.preprocessors import FeatureVectorPreprocessor
+from sstar.preprocessors import GenotypeMatrixPreprocessor
 
 
 def preprocess_feature_vectors(

--- a/sstar/preprocessors/feature_vector_preprocessor.py
+++ b/sstar/preprocessors/feature_vector_preprocessor.py
@@ -20,10 +20,10 @@
 import yaml
 import numpy as np
 from typing import Any
-from gaishi.configs import FeatureConfig
-from gaishi.preprocessors import GenericPreprocessor
-from gaishi.registries.stat_registry import STAT_REGISTRY
-from gaishi.utils import parse_ind_file
+from sstar.configs import FeatureConfig
+from sstar.preprocessors import GenericPreprocessor
+from sstar.registries.stat_registry import STAT_REGISTRY
+from sstar.utils import parse_ind_file
 
 
 class FeatureVectorPreprocessor(GenericPreprocessor):

--- a/sstar/simulate.py
+++ b/sstar/simulate.py
@@ -20,10 +20,10 @@
 import os, random, shutil
 import pandas as pd
 from multiprocessing import Lock, Value
-from gaishi.multiprocessing import mp_manager
-from gaishi.generators import RandomNumberGenerator
-from gaishi.simulators import FeatureVectorSimulator
-from gaishi.simulators import GenotypeMatrixSimulator
+from sstar.multiprocessing import mp_manager
+from sstar.generators import RandomNumberGenerator
+from sstar.simulators import FeatureVectorSimulator
+from sstar.simulators import GenotypeMatrixSimulator
 
 
 def simulate_feature_vectors(

--- a/sstar/simulators/feature_vector_simulator.py
+++ b/sstar/simulators/feature_vector_simulator.py
@@ -19,11 +19,11 @@
 
 import os
 from typing import Any
-from gaishi.simulators import GenericSimulator
-from gaishi.simulators import MsprimeSimulator
-from gaishi.generators import WindowDataGenerator
-from gaishi.labelers import BinaryWindowLabeler
-from gaishi.preprocessors import FeatureVectorPreprocessor
+from sstar.simulators import GenericSimulator
+from sstar.simulators import MsprimeSimulator
+from sstar.generators import WindowDataGenerator
+from sstar.labelers import BinaryWindowLabeler
+from sstar.preprocessors import FeatureVectorPreprocessor
 
 
 class FeatureVectorSimulator(GenericSimulator):

--- a/sstar/simulators/msprime_simulator.py
+++ b/sstar/simulators/msprime_simulator.py
@@ -19,7 +19,7 @@
 
 import demes, msprime, os, tskit
 import pyranges as pr
-from gaishi.simulators import GenericSimulator
+from sstar.simulators import GenericSimulator
 
 
 class MsprimeSimulator(GenericSimulator):

--- a/sstar/stats/sstar.py
+++ b/sstar/stats/sstar.py
@@ -20,8 +20,8 @@
 import numpy as np
 from typing import Dict, Any, List
 from scipy.spatial import distance_matrix
-from gaishi.registries.stat_registry import STAT_REGISTRY
-from gaishi.stats import GenericStatistic
+from sstar.registries.stat_registry import STAT_REGISTRY
+from sstar.stats import GenericStatistic
 
 
 @STAT_REGISTRY.register("sstar")

--- a/sstar/train.py
+++ b/sstar/train.py
@@ -20,11 +20,11 @@
 import os
 import yaml
 from typing import Optional
-from gaishi.configs import GlobalConfig
-from gaishi.registries.model_registry import MODEL_REGISTRY
-from gaishi.simulate import simulate_feature_vectors
-from gaishi.simulate import simulate_genotype_matrices
-from gaishi.utils import UniqueKeyLoader, filter_model_params_for_method
+from sstar.configs import GlobalConfig
+from sstar.registries.model_registry import MODEL_REGISTRY
+from sstar.simulate import simulate_feature_vectors
+from sstar.simulate import simulate_genotype_matrices
+from sstar.utils import UniqueKeyLoader, filter_model_params_for_method
 
 
 def train(
@@ -41,7 +41,7 @@ def train(
     demes : str
         Path to the demography (demes) YAML file used for simulation.
     config : str
-        Path to the gaishi configuration YAML file.
+        Path to the sstar configuration YAML file.
     output : str, optional
         Output path or directory passed to the model's `train` method, used
         to store the trained model. Required when `only_simulation=False`.


### PR DESCRIPTION
### Motivation
- The codebase had lingering imports and docstrings referencing the old package name `gaishi`, which would break imports after the project namespace changed to `sstar`.
- This change consolidates package references to ensure internal imports resolve correctly without changing runtime behavior or public interfaces.

### Description
- Replaced `gaishi.*` imports with `sstar.*` across core modules including `train.py`, `infer.py`, `preprocess.py`, `simulate.py`, `generators/`, `simulators/`, `preprocessors/`, `stats/`, `configs/`, and `multiprocessing/mp_manager.py`.
- Updated related docstrings/comments that referenced the old project name from `gaishi` to `sstar` for naming consistency.
- No changes were made to function signatures, filenames, runtime semantics, or outputs.
- No new dependencies were introduced.

### Testing
- Ran `pytest -q`, which discovered no tests in this repository (no tests ran).
- Ran `black --check sstar`, which reported three existing files would be reformatted but the reported files were not modified by this PR.
- Ran `flake8 sstar`, but `flake8` was not available in the environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08af32bbbc832cb2ea625da0675e84)

## Summary by Sourcery

Update internal imports and references to use the new sstar package namespace instead of the legacy gaishi name.

Enhancements:
- Standardize module imports across core training, inference, preprocessing, simulation, generator, simulator, config, and stats modules to reference sstar instead of gaishi.
- Align configuration and model validation docstrings with the sstar naming to reflect the current project namespace.

Chores:
- Adjust multiprocessing and utility module references to the sstar namespace to keep internal package structure consistent after the rename.