### PR TITLE
Remove obsolete sample-name helper from utils

### DIFF
--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -18,9 +18,7 @@
 #    https://www.gnu.org/licenses/gpl-3.0.en.html
 
 import allel
-import math
 import numpy as np
-from multiprocessing import Process, Queue
 from typing import Any, Callable
 
 
@@ -418,42 +416,6 @@ def split_genome(
                 )
 
     return window_positions
-
-
-def create_sample_name_list(
-    samples: list,
-    ploidy: int,
-    is_phased: bool,
-) -> list[str]:
-    """
-    Create a list of sample names, including phased information if applicable.
-
-    Parameters
-    ----------
-    samples : list of str
-        List of original sample identifiers.
-    ploidy : int
-        The ploidy level of the samples (e.g., 2 for diploid).
-    is_phased : bool
-        Indicates if the sample names should include phased information.
-
-    Returns
-    -------
-    list of str
-        A list of sample names, with phased information if applicable.
-    """
-
-    if is_phased:
-        num_samples = len(samples) * ploidy
-    else:
-        num_samples = len(samples)
-
-    samples = [
-        f"{samples[int(i/ploidy)]}_{i%ploidy+1}" if is_phased else samples[i]
-        for i in range(num_samples)
-    ]
-
-    return samples
 
 
 def filter_model_params_for_method(


### PR DESCRIPTION
### Motivation
- The helper `create_sample_name_list` in `sstar/utils/utils.py` was not referenced anywhere in the repository and appears to be dead code, so removing it reduces maintenance burden without changing workflow semantics.

### Description
- Deleted the unused `create_sample_name_list` function and removed now-dead imports (`math`, `Process`, `Queue`) from `sstar/utils/utils.py`, with no changes to data-loading or preprocessing paths.

### Testing
- Verified there are no remaining references with `rg`/ripgrep; formatting with `black` succeeded; attempted `flake8` but it is not installed in this environment so static linting could not be run there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a096a468710832ca05004f71498ab96)

## Summary by Sourcery

Enhancements:
- Clean up the utils module by deleting the obsolete create_sample_name_list helper and its unused imports.