### PR TITLE
docs: add Pepy total downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![build status](https://img.shields.io/github/actions/workflow/status/xin-huang/sstar/build.yaml?branch=main&style=flat-square)](https://github.com/xin-huang/sstar/actions)
 [![codecov](https://img.shields.io/codecov/c/github/xin-huang/sstar?style=flat-square)](https://app.codecov.io/gh/xin-huang/sstar)
 [![docs](https://img.shields.io/github/actions/workflow/status/xin-huang/sstar/pages/pages-build-deployment?style=flat-square&label=docs)](https://github.com/xin-huang/sstar/deployments/github-pages)
+[![downloads](https://img.shields.io/pepy/dt/sstar?style=flat-square)](https://pepy.tech/projects/sstar)
 
 The manual can be found [here](https://xin-huang.github.io/sstar).
 


### PR DESCRIPTION
### Motivation
- Add a Pepy/Shields.io badge to the README to display total PyPI download counts for `sstar`.

### Description
- Inserted a Shields.io Pepy badge line in `README.md`: `[![downloads](https://img.shields.io/pepy/dt/sstar?style=flat-square)](https://pepy.tech/projects/sstar)`.

### Testing
- No automated tests were run since this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a50ff28c832c879be73a71cf3f16)

## Summary by Sourcery

Documentation:
- Add a Pepy/Shields.io total downloads badge to the README badges section.