### PR TITLE
Consolidate simulation output paths into single `output_file` field

### DIFF
--- a/sstar/configs/simulation_config.py
+++ b/sstar/configs/simulation_config.py
@@ -57,8 +57,9 @@ class SimulationConfig(BaseModel):
     )
 
     # Output
-    output_prefix: str = Field(..., description="Filename prefix for outputs")
-    output_dir: Path = Field(..., description="Directory for all outputs")
+    output_file: Path = Field(
+        ..., description="Output TSV file path for simulated features"
+    )
     keep_sim_data: bool = Field(
         False,
         description="Whether to keep raw simulation data (trees, msprime/demes outputs, etc.)",
@@ -79,8 +80,8 @@ class SimulationConfig(BaseModel):
     # Features
     nfeature: int = Field(..., gt=0, description="Number of features to sample/output")
 
-    @field_validator("output_dir")
+    @field_validator("output_file")
     @classmethod
-    def _ensure_output_dir(cls, p: Path) -> Path:
+    def _ensure_output_file(cls, p: Path) -> Path:
         # Do not create here; just normalize path
         return p.expanduser().resolve()

--- a/sstar/simulate.py
+++ b/sstar/simulate.py
@@ -38,8 +38,7 @@ def simulate(
     mut_rate: float,
     rec_rate: float,
     feature_config_file: str,
-    output_prefix: str,
-    output_dir: str,
+    output_file: str,
     nfeature: int,
     is_phased: bool,
     is_shuffled: bool,
@@ -78,10 +77,8 @@ def simulate(
         Recombination rate per base pair per generation.
     feature_config_file : str
         Path to the YAML configuration file specifying features to compute.
-    output_prefix : str
-        Prefix for output files.
-    output_dir : str
-        Directory to save output files.
+    output_file : str
+        Output TSV file path for simulated features.
     nfeature : int
         Total number of features to generate.
     is_phased : bool
@@ -112,8 +109,10 @@ def simulate(
     if nfeature <= 0:
         raise ValueError("nfeature must be positive.")
 
-    os.makedirs(output_dir, exist_ok=True)
-    output_file = os.path.join(output_dir, f"{output_prefix}.tsv")
+    output_dir = os.path.dirname(output_file)
+    output_prefix = os.path.splitext(os.path.basename(output_file))[0]
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
 
     simulator = MsprimeSimulator(
         demo_model_file=demo_model_file,

--- a/sstar/train.py
+++ b/sstar/train.py
@@ -58,7 +58,7 @@ def train(
         raise ValueError(f"Error parsing YAML configuration file '{config}': {e}")
 
     global_config = GlobalConfig(**config_dict)
-    data = f"{global_config.simulation.output_dir}/{global_config.simulation.output_prefix}.tsv"
+    data = str(global_config.simulation.output_file)
     if not os.path.exists(data):
         print("Training data is not found. Perform simulation.")
         simulation_params = filter_model_params_for_method(

--- a/tests/test_simulation_config.py
+++ b/tests/test_simulation_config.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Xin Huang
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+from pathlib import Path
+
+from sstar.configs.simulation_config import SimulationConfig
+
+
+def test_simulation_config_normalizes_output_file(tmp_path):
+    rel_out = tmp_path / "nested" / "sim.features.tsv"
+    cfg = SimulationConfig(
+        nrep=1,
+        nref=2,
+        ntgt=2,
+        ref_id="REF",
+        tgt_id="TGT",
+        src_id="SRC",
+        ploidy=2,
+        is_phased=True,
+        seq_len=1000,
+        mut_rate=1e-8,
+        rec_rate=1e-8,
+        nprocess=1,
+        force_balanced=False,
+        output_file=rel_out,
+        keep_sim_data=False,
+        seed=1,
+        feature_config_file=tmp_path / "feature.yml",
+        is_shuffled=True,
+        nfeature=10,
+    )
+
+    assert cfg.output_file == Path(rel_out).expanduser().resolve()


### PR DESCRIPTION
### Motivation
- Simplify downstream handling of simulation outputs by replacing separate `output_prefix` and `output_dir` fields with a single `output_file` path in the simulation config and runtime APIs.

### Description
- Replace `output_prefix: str` and `output_dir: Path` on `SimulationConfig` with a single `output_file: Path` and update the validator to normalize the path via `expanduser().resolve()`.
- Update `simulate` signature to accept `output_file` and derive `output_dir` and `output_prefix` from it, creating the parent directory as needed, and pass those to `MsprimeSimulator`.
- Update `train` to read the training data path from `global_config.simulation.output_file` instead of composing it from `output_dir`/`output_prefix`.
- Add a unit test `tests/test_simulation_config.py::test_simulation_config_normalizes_output_file` to assert that `SimulationConfig` normalizes `output_file` to an absolute resolved `Path`.

### Testing
- Added `tests/test_simulation_config.py` which constructs a `SimulationConfig` with a nested relative `output_file` and asserts normalization, and this test passed under `pytest`.
- No other automated tests were modified; the new test executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11552844bc832cbdaf98ccbdd2c2c3)

## Summary by Sourcery

Consolidate simulation output configuration to use a single normalized output file path across simulation and training workflows.

New Features:
- Allow simulations to be configured with a single output_file path instead of separate output_dir and output_prefix fields.

Enhancements:
- Normalize simulation output_file paths via a validator that expands and resolves them to absolute Paths.
- Derive output directory and filename prefix from the configured output_file within the simulate routine, creating parent directories only when needed.
- Update training to consume the unified simulation output_file path when locating training data.

Tests:
- Add a unit test verifying that SimulationConfig normalizes a relative output_file path to an absolute resolved Path.