### PR TITLE
Remove trailing blank lines from docstrings

### DIFF
--- a/sstar/feature_vector_preprocessor.py
+++ b/sstar/feature_vector_preprocessor.py
@@ -32,7 +32,6 @@ class FeatureVectorPreprocessor:
     This class extends DataPreprocessor to include additional functionality for creating
     feature vectors based on genomic variants, reference and target individual genotypes,
     and window-based genomic statistics.
-
     """
 
     def __init__(self, ref_ind_file: str, tgt_ind_file: str, feature_config_file: str):
@@ -54,7 +53,6 @@ class FeatureVectorPreprocessor:
             If the feature configuration file is not found.
         ValueError
             If the feature configuration file is incorrectly formatted or does not contain any features.
-
         """
         try:
             with open(feature_config_file, "r") as f:
@@ -111,7 +109,6 @@ class FeatureVectorPreprocessor:
         -------
         list
             A list of dictionaries containing the formatted feature vectors for the genomic window.
-
         """
         params = {
             "ref_gts": ref_gts,
@@ -162,7 +159,6 @@ class FeatureVectorPreprocessor:
         -------
         list
             A list of dictionaries containing the formatted results with one row per sample and one column per feature.
-
         """
         if is_phased:
             num_samples = len(self.samples["tgt"]) * ploidy

--- a/sstar/generators/generic_generator.py
+++ b/sstar/generators/generic_generator.py
@@ -27,7 +27,6 @@ class GenericGenerator(ABC):
     This class defines a common interface for data generation. Subclasses
     must implement the get method to generate data according to specific
     requirements or configurations provided via keyword arguments.
-
     """
 
     @abstractmethod
@@ -45,6 +44,5 @@ class GenericGenerator(ABC):
         Returns:
         The generated data, the format and type of which are determined by the
         subclass implementation.
-
         """
         pass

--- a/sstar/generators/random_number_generator.py
+++ b/sstar/generators/random_number_generator.py
@@ -24,7 +24,6 @@ from sstar.generators import GenericGenerator
 class RandomNumberGenerator(GenericGenerator):
     """
     Generates random numbers based on specified parameters.
-
     """
 
     def __init__(self, nrep: int, start_rep: int = 0, seed: int = None):
@@ -46,7 +45,6 @@ class RandomNumberGenerator(GenericGenerator):
         ------
         ValueError
             If `nrep` is less than or equal to 0, or `start_rep` is negative.
-
         """
         if nrep <= 0:
             raise ValueError("nrep must be greater than 0.")
@@ -76,7 +74,6 @@ class RandomNumberGenerator(GenericGenerator):
             A dictionary with two keys: 'rep' and 'seed'. 'rep' corresponds to the replicate number,
             and 'seed' corresponds to the random seed for that replicate. Each call to `get()`
             yields a new dictionary for the next replicate until all replicates are exhausted.
-
         """
         for rep, seed in zip(self.rep_list, self.seed_list):
             yield {"rep": rep, "seed": seed}

--- a/sstar/mp_manager.py
+++ b/sstar/mp_manager.py
@@ -48,7 +48,6 @@ def monitor(shared_dict: dict, workers: list[multiprocessing.Process]) -> None:
     - In case of a worker failure (process is no longer alive but hasn't marked 'Completed'),
       `terminate_all_workers` is called to gracefully shutdown all workers.
     - The function uses a 1-second interval for periodic checks to balance responsiveness with efficiency.
-
     """
     while True:
         # alive_workers = [worker.name for worker in workers if worker.is_alive()]
@@ -89,7 +88,6 @@ def terminate_all_workers(workers: list[multiprocessing.Process]) -> None:
       all work has been completed.
     - It first sends a `terminate` signal to each worker and then waits for each process to join,
       guaranteeing that no worker process is left hanging.
-
     """
     for w in workers:
         w.terminate()
@@ -142,7 +140,6 @@ def mp_manager(
       for task distribution and worker status monitoring.
     - To ensure smooth termination and cleanup, a monitoring thread is used to join all worker
       processes, and `cleanup_on_sigterm` is called to handle sudden terminations gracefully.
-
     """
     try:
         from pytest_cov.embed import cleanup_on_sigterm
@@ -231,7 +228,6 @@ def mp_worker(
       and exits.
     - If an exception occurs, it marks itself as 'Failed' and posts the error to `out_queue`
       before breaking the loop and terminating.
-
     """
     process_name = current_process().name
     shared_dict[process_name] = "Started"

--- a/sstar/parsers/argument_validation.py
+++ b/sstar/parsers/argument_validation.py
@@ -38,7 +38,6 @@ def positive_int(value: str) -> int:
     ------
     argparse.ArgumentTypeError
         If the value is not a valid integer or positive integer.
-
     """
     if value is not None:
         try:
@@ -68,7 +67,6 @@ def positive_number(value: str) -> float:
     ------
     argparse.ArgumentTypeError
         If the value is not a valid number or positive number.
-
     """
     if value is not None:
         try:
@@ -98,7 +96,6 @@ def existed_file(value: str) -> str:
     ------
     argparse.ArgumentTypeError
         If the file does not exist.
-
     """
     if value is not None:
         if not os.path.isfile(value):

--- a/sstar/simulate.py
+++ b/sstar/simulate.py
@@ -101,7 +101,6 @@ def simulate(
     The simulation process is dependent on the correctness of the `LRTrainingDataSimulator`,
     `RandomNumberGenerator`, and the feature computation classes. Ensure these components are correctly
     implemented and tested.
-
     """
     if nfeature <= 0:
         raise ValueError("nfeature must be positive.")


### PR DESCRIPTION
### Motivation
- Clean up docstring formatting by removing extraneous blank lines immediately before closing triple quotes, without changing any logic or public interfaces.

### Description
- Removed trailing blank lines from docstrings in these files: `sstar/feature_vector_preprocessor.py`, `sstar/mp_manager.py`, `sstar/simulate.py`, `sstar/parsers/argument_validation.py`, `sstar/generators/generic_generator.py`, and `sstar/generators/random_number_generator.py`; changes are formatting-only.

### Testing
- Ran the automated cleanup script (`python - <<'PY' ... PY`) to apply the edits and inspected the resulting diffs to confirm only docstring trailing blank lines were removed, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a117f8912dc832cbf7a36de1ddde511)

## Summary by Sourcery

Enhancements:
- Standardize docstring layout by removing superfluous blank lines at the end of docstrings in preprocessing, multiprocessing management, simulation, argument validation, and generator modules.