### PR TITLE
Lock ONNX Runtime thread counts in quantile_regression.infer

### DIFF
--- a/sstar/quantile_regression.py
+++ b/sstar/quantile_regression.py
@@ -99,7 +99,14 @@ def infer(
     df = pd.read_csv(data, sep="\t")
     mask = df["Region_ind_SNP_number"].notna()
     df["Predicted_S*_score"] = np.nan
-    session = ort.InferenceSession(model, providers=["CPUExecutionProvider"])
+    session_options = ort.SessionOptions()
+    session_options.intra_op_num_threads = 1
+    session_options.inter_op_num_threads = 1
+    session = ort.InferenceSession(
+        model,
+        sess_options=session_options,
+        providers=["CPUExecutionProvider"],
+    )
     input_name = session.get_inputs()[0].name
     predictions = session.run(
         None,


### PR DESCRIPTION
### Motivation
- Ensure inference does not oversubscribe CPUs or exhibit nondeterministic parallelism by fixing ONNX Runtime thread usage in `quantile_regression.infer`.

### Description
- Create an `ort.SessionOptions`, set `intra_op_num_threads = 1` and `inter_op_num_threads = 1`, and pass it to `ort.InferenceSession(..., sess_options=...)` when loading the ONNX model in `infer`.

### Testing
- Ran `black --check sstar/quantile_regression.py` (passed), attempted `flake8` but it is not installed in this environment, and ran `pytest -q` which failed during collection due to missing runtime dependencies (for example `numpy`, `pandas`, `yaml`) and package import setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131b288288832c90f9dc253d1e2a7a)

## Summary by Sourcery

Enhancements:
- Configure ONNX Runtime SessionOptions in quantile_regression.infer to limit intra-op and inter-op thread counts to one for CPUExecutionProvider sessions.