### PR TITLE
Restore tab delimiter for score file parsing in cal_match_rate

### DIFF
--- a/sstar/cal_match_rate.py
+++ b/sstar/cal_match_rate.py
@@ -416,7 +416,7 @@ def _cal_match_pct_ind(
     """
     res = []
     for line in data:
-        elements = line.split("	")
+        elements = line.split("\t")
         chr_name = elements[score_col["chrom"]]
         win_start = int(elements[score_col["start"]])
         win_end = int(elements[score_col["end"]])

--- a/sstar/cal_match_rate.py
+++ b/sstar/cal_match_rate.py
@@ -442,10 +442,10 @@ def _cal_match_pct_ind(
                 hap2_match_pct = hap2_res[-1]
 
                 res.append(
-                    f"{chr_name}	{win_start}	{win_end}	{sample}	1	{hap1_match_pct}	{src_sample}"
+                    f"{chr_name}\t{win_start}\t{win_end}\t{sample}\t1\t{hap1_match_pct}\t{src_sample}"
                 )
                 res.append(
-                    f"{chr_name}	{win_start}	{win_end}	{sample}	2	{hap2_match_pct}	{src_sample}"
+                    f"{chr_name}\t{win_start}\t{win_end}\t{sample}\t2\t{hap2_match_pct}\t{src_sample}"
                 )
             else:
                 # NEW: unphased output uses dosage-based formula on S* SNP positions
@@ -464,7 +464,7 @@ def _cal_match_pct_ind(
                 match_pct = calc_match_pct(tgt_dos, src_dos, P=2)
 
                 res.append(
-                    f"{chr_name}	{win_start}	{win_end}	{sample}	{hap_index}	{match_pct}	{src_sample}"
+                    f"{chr_name}\t{win_start}\t{win_end}\t{sample}\t{hap_index}\t{match_pct}\t{src_sample}"
                 )
 
     return res


### PR DESCRIPTION
### Motivation
- Restore explicit tab delimiter when parsing per-row fields in `sstar/cal_match_rate.py` so score-file rows are correctly interpreted as tab-delimited rather than relying on a space-like literal.

### Description
- Replace `elements = line.split("\t")` usage that previously contained a literal tab with an explicit escaped tab string by changing the line from `elements = line.split("\t")` (literal) to `elements = line.split("\t")` (escaped `"\t"`) so splitting is unambiguous.

### Testing
- No automated tests were run for this small delimiter-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149b20ec2c832c99fd40c43cf7cc95)

## Summary by Sourcery

Bug Fixes:
- Fix score file field splitting by explicitly using a tab character as the delimiter when parsing each line.