### PR TITLE
Validate ModelConfig.params keys against GradientBoostingRegressor signature

### DIFF
--- a/sstar/configs/model_config.py
+++ b/sstar/configs/model_config.py
@@ -34,11 +34,13 @@ class ModelConfig(BaseModel):
     @model_validator(mode="after")
     def validate_known_keys(self):
         """
-        Validate keys against GradientBoostingRegressor signature plus sstar-specific keys.
+        Validate `params` against the GradientBoostingRegressor signature.
         """
         allowed_keys = set(inspect.signature(GradientBoostingRegressor).parameters)
-        unknown_keys = set(self.model_extra or {}).difference(allowed_keys)
+        unknown_keys = set(self.params).difference(allowed_keys)
+
         if unknown_keys:
             unknown_str = ", ".join(sorted(unknown_keys))
             raise ValueError(f"Unknown GradientBoostingRegressor params: {unknown_str}")
+
         return self

--- a/sstar/configs/model_config.py
+++ b/sstar/configs/model_config.py
@@ -19,10 +19,11 @@
 
 
 import inspect
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from sklearn.ensemble import GradientBoostingRegressor
 
 
@@ -30,6 +31,19 @@ class ModelConfig(BaseModel):
     params: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="forbid")
+
+
+    @field_validator("params", mode="before")
+    @classmethod
+    def validate_params_mapping(cls, value: Any) -> dict[str, Any]:
+        """
+        Validate that `params` is provided as a mapping.
+        """
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise TypeError("`params` must be a mapping (e.g., dict[str, Any]).")
+        return dict(value)
 
     @model_validator(mode="after")
     def validate_known_keys(self):

--- a/sstar/configs/model_config.py
+++ b/sstar/configs/model_config.py
@@ -32,7 +32,6 @@ class ModelConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-
     @field_validator("params", mode="before")
     @classmethod
     def validate_params_mapping(cls, value: Any) -> dict[str, Any]:

--- a/tests/data/test.config.yaml
+++ b/tests/data/test.config.yaml
@@ -28,7 +28,7 @@ preprocessing:
 model:
   params:
     loss: "quantile"
-    quantile: 0.9
+    alpha: 0.9
     n_estimators: 200
     max_depth: 3
     random_state: 12345


### PR DESCRIPTION
### Motivation
- Ensure the validator checks keys provided in `params` rather than `model_extra`, so user-supplied model parameters are validated against the `GradientBoostingRegressor` constructor.

### Description
- Change `ModelConfig.validate_known_keys` to compute `unknown_keys = set(self.params).difference(allowed_keys)`, update the validator docstring, and keep `model_config = ConfigDict(extra="forbid")` unchanged (file: `sstar/configs/model_config.py`).

### Testing
- Ran `python -m pytest -q`, and test collection failed in this environment due to missing dependencies (`numpy`, `pandas`, `pydantic`, `yaml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1748da3c88832c8e9ce20c678b392c)

## Summary by Sourcery

Bug Fixes:
- Ensure ModelConfig rejects unknown GradientBoostingRegressor parameters based on keys in params rather than model_extra.