### PR TITLE
Remove unused `is_phased` parameter from `read_data` and clean up dead code

### DIFF
--- a/sstar/cal_s_star.py
+++ b/sstar/cal_s_star.py
@@ -74,7 +74,6 @@ def cal_s_star(
         tgt_ind_file=tgt_ind_file,
         src_ind_file=None,
         anc_allele_file=anc_allele_file,
-        is_phased=is_phased,
     )
 
     # --- Convert GT to 2D: phased haplotypes or genotype dosage -------------

--- a/sstar/utils.py
+++ b/sstar/utils.py
@@ -136,7 +136,6 @@ def read_data(
     tgt_ind_file: Optional[str],
     src_ind_file: Optional[str],
     anc_allele_file: Optional[str],
-    is_phased: Optional[bool] = None,
 ) -> Tuple[
     Optional[dict],
     Optional[list],
@@ -160,8 +159,6 @@ def read_data(
         Path to the file containing source individual IDs. If None, source data is not loaded.
     anc_allele_file : str or None
         Path to the ancestral allele file. If None, ancestral allele filtering is not applied.
-    is_phased : bool or None, optional
-        Placeholder flag for phased or dosage processing. Default: `None`.
 
     Returns
     -------
@@ -208,16 +205,6 @@ def read_data(
             if data["src"] and (c in data["src"]):
                 src_keep = ~np.in1d(data["src"][c]["POS"], fixed_pos)
                 data["src"] = filter_data(data["src"], c, src_keep)
-
-    # --- Determine chromosome names for downstream processing -----------------
-    # Use chromosome keys from tgt > ref > src depending on availability.
-    chr_names = (data["tgt"] or data["ref"] or data["src"] or {}).keys()
-
-    for c in chr_names:
-        for k in ("ref", "tgt", "src"):
-            if not data[k] or (c not in data[k]):
-                continue
-            GT = data[k][c]["GT"]
 
     # --- Return loaded and processed data -------------------------------------
     return (


### PR DESCRIPTION
### Motivation

- Simplify the data loading API by removing an unused `is_phased` parameter from `read_data` and stop passing it from callers.
- Eliminate a vestigial chromosome iteration block that did not perform any work to reduce confusion and dead code.

### Description

- Remove the `is_phased` parameter and its docstring entry from `sstar/utils.py::read_data` and clean up related comments.
- Stop passing `is_phased` into `read_data` from `sstar/cal_s_star.py::cal_s_star` so the loader signature is consistent with its usage. 
- Delete an unused loop that determined `chr_names` and iterated over groups in `read_data`, removing dead code that had no side effects. 
- Preserve downstream logic in `cal_s_star` that converts `GT` to 2D phased haplotypes or dosages so runtime behavior is unchanged.

### Testing

- Ran the test suite with `pytest -q` which completed successfully. 
- Ran linting with `flake8 .` which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183a0b4cb0832c9f0476aaf1cf9ba8)

## Summary by Sourcery

Remove an unused parameter from the data loading API and clean up dead code in the data reading logic while preserving existing behavior.

Enhancements:
- Simplify `read_data` by removing the unused `is_phased` parameter and its documentation.
- Clean up `cal_s_star` to stop passing the removed `is_phased` argument and keep the call signature aligned with `read_data`.
- Delete an unused chromosome iteration loop in `read_data` to remove dead, no-op logic.