### PR TITLE
Add optional source population support and emit `src_gts` from window generator

### DIFF
--- a/sstar/generators/window_data_generator.py
+++ b/sstar/generators/window_data_generator.py
@@ -36,9 +36,9 @@ class WindowDataGenerator(GenericGenerator):
         win_len: int,
         win_step: int,
         anc_allele_file: str = None,
-        src_ind_file: str = None,
         ploidy: int = 2,
         is_phased: bool = True,
+        src_ind_file: str = None,
     ):
         """
         Initializes a new instance of WindowDataGenerator.
@@ -60,13 +60,13 @@ class WindowDataGenerator(GenericGenerator):
         anc_allele_file : str, optional
             The path to the file containing ancestral allele information.
             Default: None.
-        src_ind_file : str, optional
-            The path to the file containing identifiers for source individuals.
-            Default: None.
         ploidy : int, optional
             The ploidy of the genome. Default: 2.
         is_phased : bool, optional
             Specifies whether the genotype data is phased. Default: True.
+        src_ind_file : str, optional
+            The path to the file containing identifiers for source individuals.
+            Default: None.
 
         Raises
         ------

--- a/sstar/generators/window_data_generator.py
+++ b/sstar/generators/window_data_generator.py
@@ -36,6 +36,7 @@ class WindowDataGenerator(GenericGenerator):
         win_len: int,
         win_step: int,
         anc_allele_file: str = None,
+        src_ind_file: str = None,
         ploidy: int = 2,
         is_phased: bool = True,
     ):
@@ -58,6 +59,9 @@ class WindowDataGenerator(GenericGenerator):
             The step size between windows in base pairs.
         anc_allele_file : str, optional
             The path to the file containing ancestral allele information.
+            Default: None.
+        src_ind_file : str, optional
+            The path to the file containing identifiers for source individuals.
             Default: None.
         ploidy : int, optional
             The ploidy of the genome. Default: 2.
@@ -82,8 +86,15 @@ class WindowDataGenerator(GenericGenerator):
         self.ploidy = ploidy
         self.is_phased = is_phased
 
-        ref_data, ref_samples, tgt_data, tgt_samples = read_data(
-            vcf_file, ref_ind_file, tgt_ind_file, anc_allele_file, is_phased
+        ref_data, _ref_samples, tgt_data, _tgt_samples, src_data, _src_samples = (
+            read_data(
+                vcf_file,
+                ref_ind_file,
+                tgt_ind_file,
+                anc_allele_file,
+                is_phased,
+                src_ind_file,
+            )
         )
 
         if chr_name not in tgt_data:
@@ -105,9 +116,13 @@ class WindowDataGenerator(GenericGenerator):
             end = windows[w][1][1]
             ref_gts = ref_data[chr_name]["GT"]
             tgt_gts = tgt_data[chr_name]["GT"]
+            src_gts = None
+            if src_data is not None and chr_name in src_data:
+                src_gts = src_data[chr_name]["GT"]
             idx = (pos >= start) & (pos <= end)
             sub_ref_gts = ref_gts[idx]
             sub_tgt_gts = tgt_gts[idx]
+            sub_src_gts = src_gts[idx] if src_gts is not None else None
             sub_pos = pos[idx]
 
             d = {
@@ -120,6 +135,8 @@ class WindowDataGenerator(GenericGenerator):
                 "tgt_gts": sub_tgt_gts,
                 "pos": sub_pos,
             }
+            if sub_src_gts is not None:
+                d["src_gts"] = sub_src_gts
 
             self.data.append(d)
 
@@ -131,8 +148,8 @@ class WindowDataGenerator(GenericGenerator):
         ------
         dict
             A dictionary containing chromosome name, start and end positions,
-            ploidy and phase information, reference and target genotypes,
-            and positions for each window.
+            ploidy and phase information, reference, target, optional source
+            genotypes, and positions for each window.
         """
         for d in self.data:
             yield d

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -199,7 +199,7 @@ def read_data(
             ref_data = filter_data(ref_data, c, index)
             tgt_data = filter_data(tgt_data, c, index)
             if src_data is not None and c in src_data:
-                src_index = ~np.in1d(src_data[c]["POS"], fixed_pos)
+                src_index = ~np.isin(src_data[c]["POS"], fixed_pos)
                 src_data = filter_data(src_data, c, src_index)
 
     if is_phased:

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -127,6 +127,42 @@ def filter_data(data: dict, c: str, index: np.ndarray) -> dict:
     return data
 
 
+def align_data_to_positions(data: dict, c: str, target_pos: np.ndarray) -> dict:
+    """
+    Align genotype data for one chromosome to a target position order.
+
+    Parameters
+    ----------
+    data : dict
+        Genotype data to align.
+    c : str
+        Name of the chromosome to align.
+    target_pos : np.ndarray
+        Target genomic positions and order to match.
+
+    Returns
+    -------
+    dict
+        Genotype data filtered and reordered to match ``target_pos``.
+
+    Raises
+    ------
+    ValueError
+        If the genotype data is missing one or more target positions.
+    """
+    source_pos = data[c]["POS"]
+    source_index_by_pos = {pos: idx for idx, pos in enumerate(source_pos)}
+    missing_pos = [pos for pos in target_pos if pos not in source_index_by_pos]
+    if missing_pos:
+        raise ValueError(
+            f"Cannot align source data for chromosome {c}: "
+            f"missing {len(missing_pos)} target position(s)."
+        )
+
+    index = np.array([source_index_by_pos[pos] for pos in target_pos])
+    return filter_data(data, c, index)
+
+
 def read_data(
     vcf_file: str,
     ref_ind_file: str,
@@ -181,7 +217,7 @@ def read_data(
 
     if src_ind_file is not None:
         src_samples = parse_ind_file(src_ind_file)
-        src_data = read_geno_data(vcf_file, src_samples, anc_allele_file, True)
+        src_data = read_geno_data(vcf_file, src_samples, anc_allele_file, False)
 
     if (ref_ind_file is not None) and (tgt_ind_file is not None):
         chr_names = tgt_data.keys()
@@ -201,6 +237,7 @@ def read_data(
             if src_data is not None and c in src_data:
                 src_index = ~np.isin(src_data[c]["POS"], fixed_pos)
                 src_data = filter_data(src_data, c, src_index)
+                src_data = align_data_to_positions(src_data, c, tgt_data[c]["POS"])
 
     if is_phased:
         for c in chr_names:

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -133,9 +133,10 @@ def read_data(
     tgt_ind_file: str,
     anc_allele_file: str,
     is_phased: bool,
-) -> tuple[dict, list, dict, list]:
+    src_ind_file: str = None,
+) -> tuple[dict, list, dict, list, dict, list]:
     """
-    Read data from reference and target populations.
+    Read data from reference, target, and optional source populations.
 
     Parameters
     ----------
@@ -151,6 +152,8 @@ def read_data(
         Name of the file containing ancestral allele information.
     is_phased : bool
         If True, use phased genotypes; otherwise, use unphased genotypes.
+    src_ind_file : str, optional
+        Name of the file containing sample information from source populations.
 
     Returns
     -------
@@ -162,8 +165,12 @@ def read_data(
         Genotype data from target populations.
     tgt_samples : list
         Sample information from target populations.
+    src_data : dict
+        Genotype data from source populations.
+    src_samples : list
+        Sample information from source populations.
     """
-    ref_data = ref_samples = tgt_data = tgt_samples = None
+    ref_data = ref_samples = tgt_data = tgt_samples = src_data = src_samples = None
     if ref_ind_file is not None:
         ref_samples = parse_ind_file(ref_ind_file)
         ref_data = read_geno_data(vcf_file, ref_samples, anc_allele_file, True)
@@ -171,6 +178,10 @@ def read_data(
     if tgt_ind_file is not None:
         tgt_samples = parse_ind_file(tgt_ind_file)
         tgt_data = read_geno_data(vcf_file, tgt_samples, anc_allele_file, True)
+
+    if src_ind_file is not None:
+        src_samples = parse_ind_file(src_ind_file)
+        src_data = read_geno_data(vcf_file, src_samples, anc_allele_file, True)
 
     if (ref_ind_file is not None) and (tgt_ind_file is not None):
         chr_names = tgt_data.keys()
@@ -184,8 +195,12 @@ def read_data(
             )
             fixed_index = np.logical_and(ref_fixed_variants, tgt_fixed_variants)
             index = np.logical_not(fixed_index)
+            fixed_pos = ref_data[c]["POS"][fixed_index]
             ref_data = filter_data(ref_data, c, index)
             tgt_data = filter_data(tgt_data, c, index)
+            if src_data is not None and c in src_data:
+                src_index = ~np.in1d(src_data[c]["POS"], fixed_pos)
+                src_data = filter_data(src_data, c, src_index)
 
     if is_phased:
         for c in chr_names:
@@ -197,12 +212,19 @@ def read_data(
             tgt_data[c]["GT"] = np.reshape(
                 tgt_data[c]["GT"].values, (mut_num, ind_num * ploidy)
             )
+            if src_data is not None and c in src_data:
+                mut_num, ind_num, ploidy = src_data[c]["GT"].shape
+                src_data[c]["GT"] = np.reshape(
+                    src_data[c]["GT"].values, (mut_num, ind_num * ploidy)
+                )
     else:
         for c in chr_names:
             ref_data[c]["GT"] = np.sum(ref_data[c]["GT"], axis=2)
             tgt_data[c]["GT"] = np.sum(tgt_data[c]["GT"], axis=2)
+            if src_data is not None and c in src_data:
+                src_data[c]["GT"] = np.sum(src_data[c]["GT"], axis=2)
 
-    return ref_data, ref_samples, tgt_data, tgt_samples
+    return ref_data, ref_samples, tgt_data, tgt_samples, src_data, src_samples
 
 
 def get_ref_alt_allele(ref, alt, pos):
@@ -415,4 +437,3 @@ def split_genome(
                 )
 
     return window_positions
-

--- a/tests/generators/test_window_data_generator.py
+++ b/tests/generators/test_window_data_generator.py
@@ -139,6 +139,57 @@ def test_WindowDataGenerator_with_source_genotypes(init_params, file_paths, tmp_
         assert np.array_equal(generated["src_gts"], src_data[chr_name]["GT"][idx])
 
 
+def test_WindowDataGenerator_aligns_source_to_target_positions(tmp_path):
+    vcf_file = tmp_path / "source_missing.vcf"
+    vcf_file.write_text(
+        "\n".join(
+            [
+                "##fileformat=VCFv4.2",
+                "##contig=<ID=1,length=100>",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT"
+                "\tref_0\ttgt_0\tsrc_0",
+                "1\t10\t.\tA\tG\t.\tPASS\t.\tGT\t0|0\t0|0\t0|1",
+                "1\t20\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t0|0\t.|.",
+                "1\t30\t.\tA\tG\t.\tPASS\t.\tGT\t1|0\t0|1\t1|1",
+            ]
+        )
+        + "\n"
+    )
+    ref_ind_file = tmp_path / "ref.ind.list"
+    tgt_ind_file = tmp_path / "tgt.ind.list"
+    src_ind_file = tmp_path / "src.ind.list"
+    ref_ind_file.write_text("ref_0\n")
+    tgt_ind_file.write_text("tgt_0\n")
+    src_ind_file.write_text("src_0\n")
+
+    _ref_data, _ref_samples, tgt_data, _tgt_samples, src_data, _src_samples = read_data(
+        str(vcf_file),
+        str(ref_ind_file),
+        str(tgt_ind_file),
+        None,
+        True,
+        str(src_ind_file),
+    )
+
+    assert np.array_equal(src_data["1"]["POS"], tgt_data["1"]["POS"])
+
+    generator = WindowDataGenerator(
+        vcf_file=str(vcf_file),
+        chr_name="1",
+        ref_ind_file=str(ref_ind_file),
+        tgt_ind_file=str(tgt_ind_file),
+        src_ind_file=str(src_ind_file),
+        win_len=100,
+        win_step=100,
+    )
+    window = next(generator.get())
+
+    assert np.array_equal(window["pos"], np.array([10, 20, 30]))
+    assert window["src_gts"].shape[0] == window["pos"].shape[0]
+    assert np.array_equal(window["src_gts"], src_data["1"]["GT"])
+
+
 def test_window_generator_uses_closed_interval_boundaries():
     pos = np.array([1, 10, 20, 21, 30])
     start = 10

--- a/tests/generators/test_window_data_generator.py
+++ b/tests/generators/test_window_data_generator.py
@@ -106,6 +106,25 @@ def test_WindowDataGenerator(init_params, expected_params):
                 ), f"Values do not match for key {key}."
 
 
+def test_WindowDataGenerator_preserves_existing_optional_positional_args(file_paths):
+    generator = WindowDataGenerator(
+        file_paths["vcf_file"],
+        "1",
+        file_paths["ref_ind_file"],
+        file_paths["tgt_ind_file"],
+        50000,
+        50000,
+        file_paths["anc_allele_file"],
+        2,
+        file_paths["is_phased"],
+    )
+    generated_params = next(generator.get())
+
+    assert generated_params["ploidy"] == 2
+    assert generated_params["is_phased"] is True
+    assert "src_gts" not in generated_params
+
+
 def test_WindowDataGenerator_with_source_genotypes(init_params, file_paths, tmp_path):
     src_ind_file = tmp_path / "src.ind.list"
     src_ind_file.write_text("tsk_75\ntsk_76\ntsk_77\n")

--- a/tests/generators/test_window_data_generator.py
+++ b/tests/generators/test_window_data_generator.py
@@ -52,7 +52,9 @@ def expected_params(file_paths):
     chr_name = "1"
     win_len = 50000
     win_step = 50000
-    ref_data, ref_samples, tgt_data, tgt_samples = read_data(**file_paths)
+    ref_data, _ref_samples, tgt_data, _tgt_samples, _src_data, _src_samples = read_data(
+        **file_paths
+    )
     windows = split_genome(tgt_data[chr_name]["POS"], chr_name, win_step, win_len)
 
     for w in range(len(windows)):
@@ -102,6 +104,39 @@ def test_WindowDataGenerator(init_params, expected_params):
                 assert (
                     generated[key] == expected[key]
                 ), f"Values do not match for key {key}."
+
+
+def test_WindowDataGenerator_with_source_genotypes(init_params, file_paths, tmp_path):
+    src_ind_file = tmp_path / "src.ind.list"
+    src_ind_file.write_text("tsk_75\ntsk_76\ntsk_77\n")
+
+    generator = WindowDataGenerator(
+        **init_params,
+        src_ind_file=str(src_ind_file),
+    )
+    generated_params_list = list(generator.get())
+
+    ref_data, _ref_samples, tgt_data, _tgt_samples, src_data, _src_samples = read_data(
+        **file_paths,
+        src_ind_file=str(src_ind_file),
+    )
+    chr_name = init_params["chr_name"]
+    windows = split_genome(
+        tgt_data[chr_name]["POS"],
+        chr_name,
+        init_params["win_step"],
+        init_params["win_len"],
+    )
+
+    assert generated_params_list, "Expected at least one generated window."
+    for generated, window in zip(generated_params_list, windows):
+        chr_name = window[0]
+        start, end = window[1]
+        pos = tgt_data[chr_name]["POS"]
+        idx = (pos >= start) & (pos <= end)
+
+        assert "src_gts" in generated
+        assert np.array_equal(generated["src_gts"], src_data[chr_name]["GT"][idx])
 
 
 def test_window_generator_uses_closed_interval_boundaries():


### PR DESCRIPTION
### Motivation
- Produce per-window source genotypes (`src_gts`) so the generator can include a third population without rewriting the existing pipeline. 
- Reuse existing helpers (`parse_ind_file`, `read_geno_data`, `filter_data`) to keep changes minimal and maintain current ref/tgt semantics. 
- Preserve the current hom-alt fixed-site filtering policy and apply it consistently to source data for window alignment. 

### Description
- Extend `read_data` with an optional `src_ind_file: str = None` parameter and change the return shape to `ref_data, ref_samples, tgt_data, tgt_samples, src_data, src_samples` so callers always get a unified six-tuple. 
- When `src_ind_file` is provided, parse and load source genotypes via the existing `read_geno_data` path and keep `src_data` as `None` otherwise. 
- Apply the existing ref/tgt hom-alt fixed-site removal and remove the same positions from `src_data` (if present), and run the same phased/unphased reshaping/collapsing on `src` as on `ref`/`tgt`. 
- Add `src_ind_file` arg to `WindowDataGenerator` and include `src_gts` in each window dictionary when source data is available (keeps original behavior when no source is given). 
- Add `test_WindowDataGenerator_with_source_genotypes` and update `tests/generators/test_window_data_generator.py` to accommodate the unified `read_data` return and to verify per-window `src_gts` slices. 

### Testing
- Ran byte-compile checks with `python -m py_compile` which succeeded for the modified files. 
- Ran formatter checks with `python -m black --check` which passed for the changed files. 
- Ran `git diff --check` which produced no whitespace errors. 
- Attempted `pytest tests/generators/test_window_data_generator.py` but collection failed due to the test environment missing `numpy` (error: `ModuleNotFoundError: No module named 'numpy'`). 
- `flake8` could not be executed in the current environment because `flake8` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a183577c72c832c8894655605489659)

## Summary by Sourcery

Add optional source population handling throughout window data generation and testing to emit per-window source genotypes when provided.

New Features:
- Allow read_data to load an optional source population and return its genotypes and samples alongside reference and target data.
- Extend WindowDataGenerator to accept a source individual file and include per-window source genotypes in emitted window dictionaries when available.

Enhancements:
- Ensure hom-alt fixed-site filtering and phased/unphased genotype reshaping are applied consistently to optional source data for alignment with reference and target populations.

Tests:
- Add coverage for WindowDataGenerator with source genotypes and update existing tests for the unified read_data return signature.