### PR TITLE
Align reference and target genotype data by shared variant positions and add test

### DIFF
--- a/sstar/generators/window_data_generator.py
+++ b/sstar/generators/window_data_generator.py
@@ -83,7 +83,12 @@ class WindowDataGenerator(GenericGenerator):
         self.is_phased = is_phased
 
         ref_data, ref_samples, tgt_data, tgt_samples = read_data(
-            vcf_file, ref_ind_file, tgt_ind_file, anc_allele_file, is_phased
+            vcf_file,
+            ref_ind_file,
+            tgt_ind_file,
+            anc_allele_file,
+            is_phased,
+            chr_name=chr_name,
         )
 
         if chr_name not in tgt_data:

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -91,6 +91,7 @@ def read_geno_data(
             data[c]["GT"] = gt
         index = np.where(vcf["variants/CHROM"] == c)
         data = filter_data(data, c, index)
+        validate_unique_variant_positions(data, c)
         # Remove missing data
         if filter_missing:
             index = data[c]["GT"].count_missing(axis=1) == len(samples)
@@ -125,6 +126,33 @@ def filter_data(data: dict, c: str, index: np.ndarray) -> dict:
     data[c]["GT"] = allel.GenotypeArray(data[c]["GT"][index])
 
     return data
+
+
+def validate_unique_variant_positions(data: dict, c: str) -> None:
+    """
+    Raise an error if a chromosome contains duplicate variant positions.
+
+    Parameters
+    ----------
+    data : dict
+        Genotype data keyed by chromosome.
+    c : str
+        Chromosome name.
+
+    Raises
+    ------
+    ValueError
+        If duplicate variant positions are present on the chromosome.
+    """
+    pos = data[c]["POS"]
+    if len(np.unique(pos)) != len(pos):
+        unique_pos, counts = np.unique(pos, return_counts=True)
+        duplicate_pos = unique_pos[counts > 1]
+        duplicate_pos_text = ", ".join(str(p) for p in duplicate_pos)
+        raise ValueError(
+            f"Duplicate variant positions found on chromosome {c}: "
+            f"{duplicate_pos_text}"
+        )
 
 
 def align_population_data_by_position(

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -219,6 +219,7 @@ def read_data(
     tgt_ind_file: str,
     anc_allele_file: str,
     is_phased: bool,
+    chr_name: str = None,
 ) -> tuple[dict, list, dict, list]:
     """
     Read data from reference and target populations.
@@ -237,6 +238,8 @@ def read_data(
         Name of the file containing ancestral allele information.
     is_phased : bool
         If True, use phased genotypes; otherwise, use unphased genotypes.
+    chr_name : str, optional
+        If provided, align and transform only this chromosome.
 
     Returns
     -------
@@ -259,8 +262,15 @@ def read_data(
         tgt_data = read_geno_data(vcf_file, tgt_samples, anc_allele_file, True)
 
     if (ref_ind_file is not None) and (tgt_ind_file is not None):
+        if chr_name is not None:
+            chr_names = [chr_name]
+            ref_data = {c: ref_data[c] for c in chr_names if c in ref_data}
+            tgt_data = {c: tgt_data[c] for c in chr_names if c in tgt_data}
+        else:
+            chr_names = list(tgt_data.keys())
+
         ref_data, tgt_data = align_population_data_by_position(ref_data, tgt_data)
-        chr_names = tgt_data.keys()
+        chr_names = list(tgt_data.keys())
         for c in chr_names:
             # Remove variants fixed in both the reference and target individuals
             ref_fixed_variants = np.sum(ref_data[c]["GT"].is_hom_alt(), axis=1) == len(

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -127,6 +127,57 @@ def filter_data(data: dict, c: str, index: np.ndarray) -> dict:
     return data
 
 
+def align_population_data_by_position(
+    ref_data: dict,
+    tgt_data: dict,
+) -> tuple[dict, dict]:
+    """
+    Keep only variant positions shared by reference and target data.
+
+    Reference and target genotypes are read and missing-filtered separately, so
+    their retained variant positions can differ. This helper keeps the shared
+    positions per chromosome and validates that the resulting arrays are aligned
+    before downstream row-wise comparisons are performed.
+
+    Parameters
+    ----------
+    ref_data : dict
+        Reference genotype data keyed by chromosome.
+    tgt_data : dict
+        Target genotype data keyed by chromosome.
+
+    Returns
+    -------
+    tuple[dict, dict]
+        Reference and target genotype data filtered to shared, aligned variant
+        positions.
+
+    Raises
+    ------
+    ValueError
+        If a chromosome is missing from the reference data or if positions are
+        not aligned after filtering.
+    """
+    for c in tgt_data.keys():
+        if c not in ref_data:
+            raise ValueError(f"Chromosome {c} is missing from the reference data.")
+
+        common_pos = np.intersect1d(ref_data[c]["POS"], tgt_data[c]["POS"])
+        ref_index = np.isin(ref_data[c]["POS"], common_pos)
+        tgt_index = np.isin(tgt_data[c]["POS"], common_pos)
+
+        ref_data = filter_data(ref_data, c, ref_index)
+        tgt_data = filter_data(tgt_data, c, tgt_index)
+
+        if not np.array_equal(ref_data[c]["POS"], tgt_data[c]["POS"]):
+            raise ValueError(
+                "Reference and target variants are not aligned "
+                f"on chromosome {c} after filtering."
+            )
+
+    return ref_data, tgt_data
+
+
 def read_data(
     vcf_file: str,
     ref_ind_file: str,
@@ -173,6 +224,7 @@ def read_data(
         tgt_data = read_geno_data(vcf_file, tgt_samples, anc_allele_file, True)
 
     if (ref_ind_file is not None) and (tgt_ind_file is not None):
+        ref_data, tgt_data = align_population_data_by_position(ref_data, tgt_data)
         chr_names = tgt_data.keys()
         for c in chr_names:
             # Remove variants fixed in both the reference and target individuals
@@ -415,4 +467,3 @@ def split_genome(
                 )
 
     return window_positions
-

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -51,6 +51,7 @@ def read_geno_data(
     ind: list[str],
     anc_allele_file: str,
     filter_missing: bool,
+    chr_name: str = None,
 ) -> dict:
     """
     Read genotype data from a VCF file.
@@ -65,13 +66,18 @@ def read_geno_data(
         Path to the BED file containing ancestral allele information.
     filter_missing : bool
         Whether to filter out missing data.
+    chr_name : str, optional
+        If provided, read only this chromosome from the VCF.
 
     Returns
     -------
     dict
         Genotype data read from the VCF file.
     """
-    vcf = allel.read_vcf(str(vcf), alt_number=1, samples=ind)
+    vcf = allel.read_vcf(str(vcf), alt_number=1, samples=ind, region=chr_name)
+    if vcf is None:
+        raise ValueError(f"{chr_name} is not present in the VCF file.")
+
     gt = vcf["calldata/GT"]
     chr_names = np.unique(vcf["variants/CHROM"])
     samples = vcf["samples"]
@@ -239,7 +245,7 @@ def read_data(
     is_phased : bool
         If True, use phased genotypes; otherwise, use unphased genotypes.
     chr_name : str, optional
-        If provided, align and transform only this chromosome.
+        If provided, read, align, and transform only this chromosome.
 
     Returns
     -------
@@ -255,20 +261,17 @@ def read_data(
     ref_data = ref_samples = tgt_data = tgt_samples = None
     if ref_ind_file is not None:
         ref_samples = parse_ind_file(ref_ind_file)
-        ref_data = read_geno_data(vcf_file, ref_samples, anc_allele_file, True)
+        ref_data = read_geno_data(
+            vcf_file, ref_samples, anc_allele_file, True, chr_name=chr_name
+        )
 
     if tgt_ind_file is not None:
         tgt_samples = parse_ind_file(tgt_ind_file)
-        tgt_data = read_geno_data(vcf_file, tgt_samples, anc_allele_file, True)
+        tgt_data = read_geno_data(
+            vcf_file, tgt_samples, anc_allele_file, True, chr_name=chr_name
+        )
 
     if (ref_ind_file is not None) and (tgt_ind_file is not None):
-        if chr_name is not None:
-            chr_names = [chr_name]
-            ref_data = {c: ref_data[c] for c in chr_names if c in ref_data}
-            tgt_data = {c: tgt_data[c] for c in chr_names if c in tgt_data}
-        else:
-            chr_names = list(tgt_data.keys())
-
         ref_data, tgt_data = align_population_data_by_position(ref_data, tgt_data)
         chr_names = list(tgt_data.keys())
         for c in chr_names:

--- a/sstar/utils/utils.py
+++ b/sstar/utils/utils.py
@@ -163,9 +163,10 @@ def align_population_data_by_position(
     Keep only variant positions shared by reference and target data.
 
     Reference and target genotypes are read and missing-filtered separately, so
-    their retained variant positions can differ. This helper keeps the shared
-    positions per chromosome and validates that the resulting arrays are aligned
-    before downstream row-wise comparisons are performed.
+    their retained variant positions can differ. This helper mutates ``ref_data``
+    and ``tgt_data`` in place, keeping only shared positions per chromosome, and
+    validates that the resulting arrays are aligned before downstream row-wise
+    comparisons are performed.
 
     Parameters
     ----------
@@ -183,14 +184,20 @@ def align_population_data_by_position(
     Raises
     ------
     ValueError
-        If a chromosome is missing from the reference data or if positions are
-        not aligned after filtering.
+        If a chromosome is missing from the reference data, no shared positions
+        remain, or positions are not aligned after filtering.
     """
     for c in tgt_data.keys():
         if c not in ref_data:
             raise ValueError(f"Chromosome {c} is missing from the reference data.")
 
         common_pos = np.intersect1d(ref_data[c]["POS"], tgt_data[c]["POS"])
+        if len(common_pos) == 0:
+            raise ValueError(
+                "No shared variant positions between reference and target "
+                f"on chromosome {c} after filtering."
+            )
+
         ref_index = np.isin(ref_data[c]["POS"], common_pos)
         tgt_index = np.isin(tgt_data[c]["POS"], common_pos)
 

--- a/tests/generators/test_window_data_generator.py
+++ b/tests/generators/test_window_data_generator.py
@@ -111,3 +111,40 @@ def test_window_generator_uses_closed_interval_boundaries():
     idx = (pos >= start) & (pos <= end)
 
     assert np.array_equal(pos[idx], np.array([10, 20]))
+
+
+def test_window_generator_scopes_alignment_to_requested_chromosome(tmp_path):
+    vcf_file = tmp_path / "multi_chrom_no_shared.vcf"
+    ref_ind_file = tmp_path / "ref.ind.list"
+    tgt_ind_file = tmp_path / "tgt.ind.list"
+
+    vcf_file.write_text(
+        "\n".join(
+            [
+                "##fileformat=VCFv4.2",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tref1\ttgt1",
+                "1\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t0|0",
+                "1\t200\t.\tA\tG\t.\tPASS\t.\tGT\t0|0\t0|1",
+                "2\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t.|.",
+                "2\t200\t.\tA\tG\t.\tPASS\t.\tGT\t.|.\t0|1",
+            ]
+        )
+        + "\n"
+    )
+    ref_ind_file.write_text("ref1\n")
+    tgt_ind_file.write_text("tgt1\n")
+
+    generator = WindowDataGenerator(
+        vcf_file=str(vcf_file),
+        chr_name="1",
+        ref_ind_file=str(ref_ind_file),
+        tgt_ind_file=str(tgt_ind_file),
+        win_len=1000,
+        win_step=1000,
+    )
+
+    generated_windows = list(generator.get())
+    assert len(generated_windows) == 1
+    assert generated_windows[0]["chr_name"] == "1"
+    assert np.array_equal(generated_windows[0]["pos"], np.array([100, 200]))

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -188,3 +188,33 @@ def test_read_data_aligns_reference_and_target_after_missing_filtering(tmp_path)
     assert np.array_equal(tgt_data["1"]["POS"], expected_pos)
     assert np.array_equal(ref_data["1"]["POS"], tgt_data["1"]["POS"])
     assert ref_data["1"]["GT"].shape[0] == tgt_data["1"]["GT"].shape[0]
+
+
+def test_read_data_rejects_duplicate_variant_positions(tmp_path):
+    vcf_file = tmp_path / "duplicate_positions.vcf"
+    ref_ind_file = tmp_path / "ref.ind.list"
+    tgt_ind_file = tmp_path / "tgt.ind.list"
+
+    vcf_file.write_text(
+        "\n".join(
+            [
+                "##fileformat=VCFv4.2",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tref1\ttgt1",
+                "1\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t0|0",
+                "1\t100\t.\tA\tT\t.\tPASS\t.\tGT\t0|0\t0|1",
+            ]
+        )
+        + "\n"
+    )
+    ref_ind_file.write_text("ref1\n")
+    tgt_ind_file.write_text("tgt1\n")
+
+    with pytest.raises(ValueError, match="Duplicate variant positions.*100"):
+        read_data(
+            vcf_file=str(vcf_file),
+            ref_ind_file=str(ref_ind_file),
+            tgt_ind_file=str(tgt_ind_file),
+            anc_allele_file=None,
+            is_phased=True,
+        )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -218,3 +218,33 @@ def test_read_data_rejects_duplicate_variant_positions(tmp_path):
             anc_allele_file=None,
             is_phased=True,
         )
+
+
+def test_read_data_rejects_no_shared_variant_positions_after_filtering(tmp_path):
+    vcf_file = tmp_path / "no_shared_positions.vcf"
+    ref_ind_file = tmp_path / "ref.ind.list"
+    tgt_ind_file = tmp_path / "tgt.ind.list"
+
+    vcf_file.write_text(
+        "\n".join(
+            [
+                "##fileformat=VCFv4.2",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tref1\ttgt1",
+                "1\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t.|.",
+                "1\t200\t.\tA\tG\t.\tPASS\t.\tGT\t.|.\t0|1",
+            ]
+        )
+        + "\n"
+    )
+    ref_ind_file.write_text("ref1\n")
+    tgt_ind_file.write_text("tgt1\n")
+
+    with pytest.raises(ValueError, match="No shared variant positions.*chromosome 1"):
+        read_data(
+            vcf_file=str(vcf_file),
+            ref_ind_file=str(ref_ind_file),
+            tgt_ind_file=str(tgt_ind_file),
+            anc_allele_file=None,
+            is_phased=True,
+        )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -161,6 +161,7 @@ def test_read_data_aligns_reference_and_target_after_missing_filtering(tmp_path)
         "\n".join(
             [
                 "##fileformat=VCFv4.2",
+                '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
                 "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tref1\tref2\ttgt1\ttgt2",
                 "1\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|0\t0|1\t0|1\t0|0",
                 "1\t200\t.\tA\tG\t.\tPASS\t.\tGT\t.|.\t.|.\t0|1\t0|0",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -19,7 +19,7 @@
 
 import pytest
 import numpy as np
-from sstar.utils import split_genome
+from sstar.utils import read_data, split_genome
 
 
 @pytest.fixture
@@ -150,3 +150,40 @@ def test_split_genome_no_windows_created_random_polymorphisms(pos):
         str(exc_info.value)
         == "No windows could be created with the given number of polymorphisms."
     )
+
+
+def test_read_data_aligns_reference_and_target_after_missing_filtering(tmp_path):
+    vcf_file = tmp_path / "mismatched_missing.vcf"
+    ref_ind_file = tmp_path / "ref.ind.list"
+    tgt_ind_file = tmp_path / "tgt.ind.list"
+
+    vcf_file.write_text(
+        "\n".join(
+            [
+                "##fileformat=VCFv4.2",
+                "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tref1\tref2\ttgt1\ttgt2",
+                "1\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|0\t0|1\t0|1\t0|0",
+                "1\t200\t.\tA\tG\t.\tPASS\t.\tGT\t.|.\t.|.\t0|1\t0|0",
+                "1\t300\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t0|0\t.|.\t.|.",
+                "1\t400\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t0|0\t0|1\t0|0",
+                "1\t500\t.\tA\tG\t.\tPASS\t.\tGT\t1|1\t1|1\t1|1\t1|1",
+            ]
+        )
+        + "\n"
+    )
+    ref_ind_file.write_text("ref1\nref2\n")
+    tgt_ind_file.write_text("tgt1\ntgt2\n")
+
+    ref_data, _, tgt_data, _ = read_data(
+        vcf_file=str(vcf_file),
+        ref_ind_file=str(ref_ind_file),
+        tgt_ind_file=str(tgt_ind_file),
+        anc_allele_file=None,
+        is_phased=True,
+    )
+
+    expected_pos = np.array([100, 400])
+    assert np.array_equal(ref_data["1"]["POS"], expected_pos)
+    assert np.array_equal(tgt_data["1"]["POS"], expected_pos)
+    assert np.array_equal(ref_data["1"]["POS"], tgt_data["1"]["POS"])
+    assert ref_data["1"]["GT"].shape[0] == tgt_data["1"]["GT"].shape[0]


### PR DESCRIPTION
### Motivation

- Ensure downstream row-wise comparisons between reference and target populations operate on identical variant sets by keeping only shared positions per chromosome.
- Prevent silent misalignment introduced by independent missing-data filtering of reference and target genotype matrices.

### Description

- Added `align_population_data_by_position(ref_data, tgt_data)` to compute the intersection of `POS` per chromosome, filter both datasets to shared positions using `filter_data`, and validate alignment, raising `ValueError` if a chromosome is missing or positions remain misaligned.
- Integrated the new alignment helper into `read_data` so reference and target data are aligned immediately after being read and missing-filtered when both population sample lists are provided by calling `ref_data, tgt_data = align_population_data_by_position(ref_data, tgt_data)`.
- Updated tests to import `read_data` and added `test_read_data_aligns_reference_and_target_after_missing_filtering` which creates a temporary VCF and sample lists to verify that `POS` arrays and genotype matrix row counts are equal between reference and target after reading.

### Testing

- Ran `pytest tests/utils/test_utils.py` which includes the new alignment test and existing `split_genome` tests, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185cbb99c4832c81986608affc291a)

## Summary by Sourcery

Align reference and target genotype datasets on shared variant positions immediately after reading and missing-data filtering to ensure consistent downstream comparisons.

New Features:
- Add a helper to intersect variant positions per chromosome between reference and target genotype data and validate their alignment.
- Align reference and target genotype data within read_data when both population sample lists are provided.

Tests:
- Add an integration-style test that constructs a VCF with differential missingness and verifies read_data returns reference and target data with matching variant positions and genotype row counts.