### PR TITLE
Added Image Definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ examples/snakepipe/logs_slurm/*
 .coverage
 tests/results/simulation
 site
+*.sif

--- a/apptainer/sstar-1.1.3-env.yaml
+++ b/apptainer/sstar-1.1.3-env.yaml
@@ -1,0 +1,17 @@
+name: sstar
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - demes=0.2.3
+  - numpy=1.24.4
+  - pandas=2.0.3
+  - pip=24.3.1
+  - python=3.8.19
+  - scikit-allel=1.3.7
+  - scipy=1.10.1
+  - r-base=4.1.2
+  - r-essentials=4.1
+  - rpy2=3.5.11
+  - pip:
+      - sstar==1.1.3

--- a/apptainer/sstar-1.1.3.def
+++ b/apptainer/sstar-1.1.3.def
@@ -1,0 +1,29 @@
+Bootstrap: docker
+From: condaforge/miniforge3:latest
+
+%files
+    sstar-1.1.3-env.yaml /opt/sstar-1.1.3-env.yaml
+
+%post
+    set -e
+
+    mamba env create -f /opt/sstar-1.1.3-env.yaml
+    mamba clean -afy
+
+%environment
+    . /opt/conda/etc/profile.d/conda.sh
+    conda activate sstar
+    export PATH=/opt/conda/envs/sstar/bin:$PATH
+
+%runscript
+    exec sstar "$@"
+
+%test
+    . /opt/conda/etc/profile.d/conda.sh
+    conda activate sstar
+
+    python -m pip show sstar
+    python -c "import sstar; print('sstar import OK')"
+    python -c "import numpy, pandas, scipy, allel, demes, rpy2; print('Python deps OK')"
+    python -c "import rpy2.robjects as ro; print(ro.r('R.version.string')[0])"
+    sstar --help


### PR DESCRIPTION
Succesfully **added apptainer for sstar 1.1.3**

Already tested it and it worked for me

To **create the image** use:

```
cd apptainer
apptainer build sstar-1.1.3.sif sstar-1.1.3.def
``` 
(use `--fakeroot` if necessary)

then to **test** use from project root:

`apptainer test apptainer/sstar-1.1.3.sif`

and to **run directly**:

`apptainer run apptainer/sstar-1.1.3.sif --help`

**general usage**:

`apptainer exec apptainer/sstar-1.1.3.sif sstar [command] [options]`

The Image itself is rather large and therefore included in the gitignore

## Summary by Sourcery

Add Apptainer image definition and environment configuration for sstar 1.1.3 and ignore the built image artifact.

New Features:
- Introduce Apptainer definition file for building the sstar 1.1.3 container image.
- Add Conda environment specification for the sstar Apptainer image.

Build:
- Update .gitignore to exclude the generated Apptainer image artifact from version control.