### PR TITLE
update docs for apptainer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # sstar
 
-`sstar` is a Python package for detecting archaic introgression from population genetic data with S\* scores (Plagnol and Wall 2006), which can be used for detecting introgression not only in humans, but also in other species.
+`sstar` is a Python package for detecting archaic introgression from population genetic data with S\* scores ([Plagnol and Wall 2006](https://doi.org/10.1371/journal.pgen.0020105)), which can be used for detecting introgression not only in humans, but also in other species.
 
 ### Requirements
 
@@ -45,6 +45,14 @@ And it should return some paths similar to
 
 	/path/to/conda/envs/sstar/bin/python
 	/path/to/conda/envs/sstar/bin/R
+
+Users can also use [Apptainer](https://apptainer.org/) to pull a container image that includes `sstar` and `ms`:
+
+    apptainer pull sstar.sif oras://ghcr.io/xin-huang/sstar:1.2.0
+
+Then run `sstar` with:
+
+    apptainer exec sstar.sif sstar
 
 ### Citations
 

--- a/docs/userguide/quantile.md
+++ b/docs/userguide/quantile.md
@@ -25,6 +25,8 @@ Users need to install the `ms` program from [Hudson Lab](https://home.uchicago.e
 
 The expected result above can be found in [test.quantile.exp.summary](https://github.com/xin-huang/sstar/blob/main/tests/results/test.quantile.exp.summary).
 
+If users run `sstar` from [the Apptainer image](https://github.com/xin-huang/sstar/pkgs/container/sstar), `ms` is available at `/opt/ms`.
+
 ### Output
 
 An example of the output is below:


### PR DESCRIPTION
## Summary by Sourcery

Document Apptainer-based usage of sstar alongside existing installation instructions.

Documentation:
- Link the S* method reference to its DOI in the main documentation index.
- Describe how to pull and execute the sstar Apptainer container image, including bundled ms availability path in the quantile user guide.