### PR TITLE
Add `match` subcommand to compute source match rates for inferred tracts

### DIFF
--- a/sstar/__main__.py
+++ b/sstar/__main__.py
@@ -24,6 +24,7 @@ import argparse
 from sstar import __version__
 from sstar.parsers.train_parser import add_train_parser
 from sstar.parsers.infer_parser import add_infer_parser
+from sstar.parsers.matchparser import add_match_parser
 
 
 def _set_sigpipe_handler() -> None:
@@ -56,6 +57,7 @@ def _sstar_cli_parser() -> argparse.ArgumentParser:
 
     add_train_parser(subparsers)
     add_infer_parser(subparsers)
+    add_match_parser(subparsers)
 
     return top_parser
 

--- a/sstar/match.py
+++ b/sstar/match.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Xin Huang
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+import os
+from typing import Union
+
+import allel
+import numpy as np
+import pandas as pd
+
+from sstar.utils import parse_ind_file, read_geno_data
+
+
+def calc_match_pct(
+    x: Union[float, list, np.ndarray],
+    y: Union[float, list, np.ndarray],
+    P: int = 2,
+) -> Union[float, str]:
+    """
+    Calculate dosage-based match rate between two genotype dosage arrays.
+
+    Missing values must be encoded as -1 and are ignored.
+
+    Parameters
+    ----------
+    x : float, list, or numpy.ndarray
+        ALT-allele dosage values for the first genotype vector.
+    y : float, list, or numpy.ndarray
+        ALT-allele dosage values for the second genotype vector.
+    P : int, optional
+        Ploidy used to normalize dosage differences. Default: 2.
+
+    Returns
+    -------
+    float or str
+        Mean match rate in [0, 1], or "NA" if there are no callable sites.
+    """
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+    y = np.atleast_1d(np.asarray(y, dtype=float))
+
+    ok = (x >= 0) & (y >= 0)
+    if not np.any(ok):
+        return "NA"
+
+    return float(np.mean(1.0 - np.abs(x[ok] - y[ok]) / float(P)))
+
+
+def _dosage_for_positions(
+    gt: allel.GenotypeArray,
+    pos: Union[list, np.ndarray],
+    ind_index: int,
+    positions: list,
+) -> np.ndarray:
+    """
+    Return ALT dosage for one individual at exact genomic positions.
+
+    If a requested position is absent or the genotype is missing, the returned
+    dosage is -1.
+
+    Parameters
+    ----------
+    gt : allel.GenotypeArray
+        Genotype array with variant, sample, and ploidy axes.
+    pos : list or numpy.ndarray
+        Variant positions corresponding to gt.
+    ind_index : int
+        Index of the individual to extract.
+    positions : list
+        Genomic positions to query.
+
+    Returns
+    -------
+    numpy.ndarray
+        Dosage array aligned to positions.
+    """
+    pos = np.asarray(pos)
+    gt_arr = np.asarray(gt)
+    pos_to_i = {int(p): i for i, p in enumerate(pos)}
+    out = np.full(len(positions), -1.0, dtype=float)
+    idx = []
+    out_i = []
+
+    for j, p in enumerate(positions):
+        i = pos_to_i.get(int(p))
+        if i is not None:
+            idx.append(i)
+            out_i.append(j)
+
+    if not idx:
+        return out
+
+    idx = np.asarray(idx, dtype=int)
+    out_i = np.asarray(out_i, dtype=int)
+    sub = gt_arr[idx, ind_index : ind_index + 1, :]
+    g = allel.GenotypeArray(sub)
+    dos = g.to_n_alt().astype(float)
+    dos[g.is_missing()] = -1
+    out[out_i] = dos[:, 0]
+
+    return out
+
+
+def match(
+    tgt_gt: allel.GenotypeArray,
+    tgt_pos: Union[list, np.ndarray],
+    tgt_index: int,
+    src_gt: allel.GenotypeArray,
+    src_pos: Union[list, np.ndarray],
+    src_index: int,
+    positions: list,
+    P: int = 2,
+) -> Union[float, str]:
+    """
+    Calculate pairwise match rate between one target and one source individual.
+    """
+    tgt_dos = _dosage_for_positions(tgt_gt, tgt_pos, tgt_index, positions)
+    src_dos = _dosage_for_positions(src_gt, src_pos, src_index, positions)
+
+    return calc_match_pct(tgt_dos, src_dos, P)
+
+
+def _base_sample_name(sample: str, samples: list[str]) -> str:
+    """
+    Map phased tract labels back to target diploid sample names.
+    """
+    if sample in samples:
+        return sample
+
+    base, sep, suffix = sample.rpartition("_")
+    if sep and suffix.isdigit() and base in samples:
+        return base
+
+    raise ValueError(f"Target sample {sample} is not present in the target list.")
+
+
+def _resolve_chrom(chrom: object, data: dict) -> str:
+    """
+    Resolve a BED chromosome label against VCF chromosome keys.
+    """
+    chrom = str(chrom)
+    if chrom in data:
+        return chrom
+
+    if chrom.startswith("chr"):
+        alt_chrom = chrom[3:]
+    else:
+        alt_chrom = f"chr{chrom}"
+
+    if alt_chrom in data:
+        return alt_chrom
+
+    available = ", ".join(str(c) for c in data.keys())
+    raise ValueError(
+        f"Chromosome {chrom} is not present in the VCF data. "
+        f"Available chromosomes: {available}"
+    )
+
+
+def run_match(
+    vcf_file: str,
+    tgt_ind_file: str,
+    src_ind_file: str,
+    tract_file: str,
+    output_file: str,
+    ploidy: int = 2,
+) -> None:
+    """
+    Calculate source match rates for inferred tracts and write them to a TSV.
+    """
+    tgt_samples = parse_ind_file(tgt_ind_file)
+    src_samples = parse_ind_file(src_ind_file)
+
+    tgt_data = read_geno_data(vcf_file, tgt_samples, None, filter_missing=False)
+    src_data = read_geno_data(vcf_file, src_samples, None, filter_missing=False)
+
+    tracts = pd.read_csv(tract_file, sep="\t", header=None)
+    if tracts.shape[1] < 4:
+        raise ValueError(
+            "The tract file must contain at least four columns: "
+            "chrom, start, end, and sample."
+        )
+    tracts = tracts.iloc[:, :4]
+    tracts.columns = ["chrom", "start", "end", "sample"]
+
+    rows = []
+    for _, tract in tracts.iterrows():
+        chrom = tract["chrom"]
+        start = int(tract["start"])
+        end = int(tract["end"])
+        tract_sample = str(tract["sample"])
+        base_sample = _base_sample_name(tract_sample, tgt_samples)
+        tgt_index = tgt_samples.index(base_sample)
+
+        tgt_chrom = _resolve_chrom(chrom, tgt_data)
+        src_chrom = _resolve_chrom(chrom, src_data)
+        tgt_gt = tgt_data[tgt_chrom]["GT"]
+        tgt_pos = np.asarray(tgt_data[tgt_chrom]["POS"])
+        src_gt = src_data[src_chrom]["GT"]
+        src_pos = np.asarray(src_data[src_chrom]["POS"])
+
+        tgt_region_pos = tgt_pos[(tgt_pos > start) & (tgt_pos <= end)]
+        src_region_pos = src_pos[(src_pos > start) & (src_pos <= end)]
+        positions = np.union1d(tgt_region_pos, src_region_pos).astype(int).tolist()
+
+        for src_index, src_sample in enumerate(src_samples):
+            rate = match(
+                tgt_gt=tgt_gt,
+                tgt_pos=tgt_pos,
+                tgt_index=tgt_index,
+                src_gt=src_gt,
+                src_pos=src_pos,
+                src_index=src_index,
+                positions=positions,
+                P=ploidy,
+            )
+            rows.append(
+                {
+                    "chrom": chrom,
+                    "start": start,
+                    "end": end,
+                    "sample": tract_sample,
+                    "match_rate": rate,
+                    "src_sample": src_sample,
+                }
+            )
+
+    output_dir = os.path.dirname(output_file)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    columns = ["chrom", "start", "end", "sample", "match_rate", "src_sample"]
+    pd.DataFrame(rows, columns=columns).to_csv(output_file, sep="\t", index=False)

--- a/sstar/parsers/matchparser.py
+++ b/sstar/parsers/matchparser.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Xin Huang
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+import argparse
+
+from sstar.match import run_match
+from sstar.parsers.argument_validation import existed_file, positive_int
+
+
+def _run_match(args: argparse.Namespace) -> None:
+    """
+    Execute the match process with specified parameters.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        A namespace object obtained from argparse, containing specified parameters.
+    """
+    run_match(
+        vcf_file=args.vcf,
+        tgt_ind_file=args.tgt,
+        src_ind_file=args.src,
+        tract_file=args.tract_file,
+        output_file=args.output,
+        ploidy=args.ploidy,
+    )
+
+
+def add_match_parser(subparsers: argparse.ArgumentParser) -> None:
+    """
+    Initializes and configures the command-line interface parser
+    for the match subcommand.
+
+    Parameters
+    ----------
+    subparsers : argparse.ArgumentParser
+        A command-line interface parser to be configured.
+    """
+    parser = subparsers.add_parser(
+        "match", help="Calculate source match rates for inferred tracts."
+    )
+    parser.add_argument(
+        "--vcf",
+        type=existed_file,
+        required=True,
+        help="Path to the VCF file.",
+    )
+    parser.add_argument(
+        "--tgt",
+        type=existed_file,
+        required=True,
+        help="Path to the target individual list.",
+    )
+    parser.add_argument(
+        "--src",
+        type=existed_file,
+        required=True,
+        help="Path to the source individual list.",
+    )
+    parser.add_argument(
+        "--tract-file",
+        type=existed_file,
+        required=True,
+        help="Path to the inferred tract BED file from sstar2 infer.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to the output match-rate TSV file.",
+    )
+    parser.add_argument(
+        "--ploidy",
+        type=positive_int,
+        default=2,
+        help="Ploidy used to normalize dosage differences.",
+    )
+    parser.set_defaults(runner=_run_match)


### PR DESCRIPTION
## Summary by Sourcery

Add a new CLI subcommand to compute genotype match rates between inferred tracts and source individuals and write results to a TSV file.

New Features:
- Introduce a dosage-based match-rate calculation utility for comparing target and source genotypes across genomic positions.
- Add a match workflow that reads VCF, target/source sample lists, and tract intervals to compute per-tract, per-source match rates.
- Expose the new matching workflow via a match subcommand in the sstar CLI with configurable ploidy and file paths.

Enhancements:
- Add helpers to resolve phased tract sample labels to base target samples and normalize chromosome naming between BED and VCF inputs.