### PR TITLE
Add `match` subcommand to compute source match rates for inferred tracts

### DIFF
--- a/sstar/__main__.py
+++ b/sstar/__main__.py
@@ -24,6 +24,7 @@ import argparse
 from sstar import __version__
 from sstar.parsers.train_parser import add_train_parser
 from sstar.parsers.infer_parser import add_infer_parser
+from sstar.parsers.match_parser import add_match_parser
 
 
 def _set_sigpipe_handler() -> None:
@@ -56,6 +57,7 @@ def _sstar_cli_parser() -> argparse.ArgumentParser:
 
     add_train_parser(subparsers)
     add_infer_parser(subparsers)
+    add_match_parser(subparsers)
 
     return top_parser
 

--- a/sstar/match.py
+++ b/sstar/match.py
@@ -1,0 +1,281 @@
+# Copyright 2026 Xin Huang and Andrea Koca
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+import os
+from typing import Optional, Union
+
+import allel
+import numpy as np
+import pandas as pd
+
+from sstar.utils import parse_ind_file, read_geno_data
+
+
+def calc_match_pct(
+    x: Union[float, list, np.ndarray],
+    y: Union[float, list, np.ndarray],
+    P: int = 2,
+) -> Union[float, str]:
+    """
+    Calculate dosage-based match rate between two genotype dosage arrays.
+
+    Missing values must be encoded as -1 and are ignored.
+
+    Parameters
+    ----------
+    x : float, list, or numpy.ndarray
+        ALT-allele dosage values for the first genotype vector.
+    y : float, list, or numpy.ndarray
+        ALT-allele dosage values for the second genotype vector.
+    P : int, optional
+        Ploidy used to normalize dosage differences. Default: 2.
+
+    Returns
+    -------
+    float or str
+        Mean match rate in [0, 1], or "NA" if there are no callable sites.
+    """
+    x = np.atleast_1d(np.asarray(x, dtype=float))
+    y = np.atleast_1d(np.asarray(y, dtype=float))
+
+    ok = (x >= 0) & (y >= 0)
+    if not np.any(ok):
+        return "NA"
+
+    return float(np.mean(1.0 - np.abs(x[ok] - y[ok]) / float(P)))
+
+
+def _dosage_for_positions(
+    gt: allel.GenotypeArray,
+    pos: Union[list, np.ndarray],
+    ind_index: int,
+    positions: list,
+    hap_index: Optional[int] = None,
+    P: int = 2,
+) -> np.ndarray:
+    """
+    Return ALT dosage for one individual at exact genomic positions.
+
+    If a requested position is absent or the genotype is missing, the returned
+    dosage is -1.
+
+    Parameters
+    ----------
+    gt : allel.GenotypeArray
+        Genotype array with variant, sample, and ploidy axes.
+    pos : list or numpy.ndarray
+        Variant positions corresponding to gt.
+    ind_index : int
+        Index of the individual to extract.
+    positions : list
+        Genomic positions to query.
+    hap_index : int or None, optional
+        Haplotype index to extract for phased targets. When None, return
+        diploid ALT dosage using scikit-allel's to_n_alt().
+    P : int, optional
+        Ploidy multiplier for haploid allele extraction. Default: 2.
+
+    Returns
+    -------
+    numpy.ndarray
+        Dosage array aligned to positions.
+    """
+    pos = np.asarray(pos)
+    gt_arr = np.asarray(gt)
+    pos_to_i = {int(p): i for i, p in enumerate(pos)}
+    out = np.full(len(positions), -1.0, dtype=float)
+    idx = []
+    out_i = []
+
+    for j, p in enumerate(positions):
+        i = pos_to_i.get(int(p))
+        if i is not None:
+            idx.append(i)
+            out_i.append(j)
+
+    if not idx:
+        return out
+
+    idx = np.asarray(idx, dtype=int)
+    out_i = np.asarray(out_i, dtype=int)
+    if hap_index is None:
+        sub = gt_arr[idx, ind_index : ind_index + 1, :]
+        g = allel.GenotypeArray(sub)
+        dos = g.to_n_alt().astype(float)
+        dos[g.is_missing()] = -1
+        out[out_i] = dos[:, 0]
+        return out
+
+    alleles = gt_arr[idx, ind_index, hap_index].astype(float)
+    called = alleles >= 0
+    dos = np.full(len(idx), -1.0, dtype=float)
+    dos[called] = alleles[called] * P
+    out[out_i] = dos
+
+    return out
+
+
+def match(
+    tgt_gt: allel.GenotypeArray,
+    tgt_pos: Union[list, np.ndarray],
+    tgt_index: int,
+    src_gt: allel.GenotypeArray,
+    src_pos: Union[list, np.ndarray],
+    src_index: int,
+    positions: list,
+    P: int = 2,
+    tgt_hap_index: Optional[int] = None,
+) -> Union[float, str]:
+    """
+    Calculate pairwise match rate between one target and one source individual.
+    """
+    tgt_dos = _dosage_for_positions(
+        tgt_gt,
+        tgt_pos,
+        tgt_index,
+        positions,
+        hap_index=tgt_hap_index,
+        P=P,
+    )
+    src_dos = _dosage_for_positions(
+        src_gt,
+        src_pos,
+        src_index,
+        positions,
+        P=P,
+    )
+
+    return calc_match_pct(tgt_dos, src_dos, P)
+
+
+def _base_sample_name(sample: str, samples: list[str]) -> tuple[str, Optional[int]]:
+    """
+    Resolve a target tract label to a base sample and optional haplotype index.
+    """
+    if sample in samples:
+        return sample, None
+
+    base, sep, suffix = sample.rpartition("_")
+    if sep and suffix in {"1", "2"} and base in samples:
+        return base, int(suffix) - 1
+
+    raise ValueError(f"Target sample {sample} is not present in the target list.")
+
+
+def _resolve_chrom(chrom: object, data: dict) -> str:
+    """
+    Resolve a BED chromosome label against VCF chromosome keys.
+    """
+    chrom = str(chrom)
+    if chrom in data:
+        return chrom
+
+    if chrom.startswith("chr"):
+        alt_chrom = chrom[3:]
+    else:
+        alt_chrom = f"chr{chrom}"
+
+    if alt_chrom in data:
+        return alt_chrom
+
+    available = ", ".join(str(c) for c in data.keys())
+    raise ValueError(
+        f"Chromosome {chrom} is not present in the VCF data. "
+        f"Available chromosomes: {available}"
+    )
+
+
+def run_match(
+    vcf_file: str,
+    tgt_ind_file: str,
+    src_ind_file: str,
+    tract_file: str,
+    output_file: str,
+    ploidy: int = 2,
+) -> None:
+    """
+    Calculate source match rates for inferred tracts and write them to a TSV.
+    """
+    tgt_samples = parse_ind_file(tgt_ind_file)
+    src_samples = parse_ind_file(src_ind_file)
+
+    tgt_data = read_geno_data(vcf_file, tgt_samples, None, filter_missing=False)
+    src_data = read_geno_data(vcf_file, src_samples, None, filter_missing=False)
+
+    tracts = pd.read_csv(tract_file, sep="\t", header=None)
+    if tracts.shape[1] < 4:
+        raise ValueError(
+            "The tract file must contain at least four columns: "
+            "chrom, start, end, and sample."
+        )
+    tracts = tracts.iloc[:, :4]
+    tracts.columns = ["chrom", "start", "end", "sample"]
+
+    rows = []
+    for _, tract in tracts.iterrows():
+        chrom = tract["chrom"]
+        start = int(tract["start"])
+        end = int(tract["end"])
+        tract_sample = str(tract["sample"])
+        base_sample, tgt_hap_index = _base_sample_name(tract_sample, tgt_samples)
+        tgt_index = tgt_samples.index(base_sample)
+
+        tgt_chrom = _resolve_chrom(chrom, tgt_data)
+        src_chrom = _resolve_chrom(chrom, src_data)
+        tgt_gt = tgt_data[tgt_chrom]["GT"]
+        tgt_pos = np.asarray(tgt_data[tgt_chrom]["POS"])
+        src_gt = src_data[src_chrom]["GT"]
+        src_pos = np.asarray(src_data[src_chrom]["POS"])
+
+        # Tract coordinates are BED-style 0-based half-open [start, end),
+        # while VCF POS values are 1-based; therefore a VCF position belongs
+        # to the tract when start < POS <= end.
+        tgt_region_pos = tgt_pos[(tgt_pos > start) & (tgt_pos <= end)]
+        src_region_pos = src_pos[(src_pos > start) & (src_pos <= end)]
+        positions = np.union1d(tgt_region_pos, src_region_pos).astype(int).tolist()
+
+        for src_index, src_sample in enumerate(src_samples):
+            rate = match(
+                tgt_gt=tgt_gt,
+                tgt_pos=tgt_pos,
+                tgt_index=tgt_index,
+                src_gt=src_gt,
+                src_pos=src_pos,
+                src_index=src_index,
+                positions=positions,
+                tgt_hap_index=tgt_hap_index,
+                P=ploidy,
+            )
+            rows.append(
+                {
+                    "chrom": chrom,
+                    "start": start,
+                    "end": end,
+                    "sample": tract_sample,
+                    "match_rate": rate,
+                    "src_sample": src_sample,
+                }
+            )
+
+    output_dir = os.path.dirname(output_file)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
+    columns = ["chrom", "start", "end", "sample", "match_rate", "src_sample"]
+    pd.DataFrame(rows, columns=columns).to_csv(output_file, sep="\t", index=False)

--- a/sstar/parsers/match_parser.py
+++ b/sstar/parsers/match_parser.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Xin Huang and Andrea Koca
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+import argparse
+
+from sstar.match import run_match
+from sstar.parsers.argument_validation import existed_file, positive_int
+
+
+def _run_match(args: argparse.Namespace) -> None:
+    """
+    Execute the match process with specified parameters.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        A namespace object obtained from argparse, containing specified parameters.
+    """
+    run_match(
+        vcf_file=args.vcf,
+        tgt_ind_file=args.tgt,
+        src_ind_file=args.src,
+        tract_file=args.tract_file,
+        output_file=args.output,
+        ploidy=args.ploidy,
+    )
+
+
+def add_match_parser(subparsers: argparse.ArgumentParser) -> None:
+    """
+    Initializes and configures the command-line interface parser
+    for the match subcommand.
+
+    Parameters
+    ----------
+    subparsers : argparse.ArgumentParser
+        A command-line interface parser to be configured.
+    """
+    parser = subparsers.add_parser(
+        "match", help="Calculate source match rates for inferred tracts."
+    )
+    parser.add_argument(
+        "--vcf",
+        type=existed_file,
+        required=True,
+        help="Path to the VCF file.",
+    )
+    parser.add_argument(
+        "--tgt",
+        type=existed_file,
+        required=True,
+        help="Path to the target individual list.",
+    )
+    parser.add_argument(
+        "--src",
+        type=existed_file,
+        required=True,
+        help="Path to the source individual list.",
+    )
+    parser.add_argument(
+        "--tract-file",
+        type=existed_file,
+        required=True,
+        help="Path to the inferred tract BED file from sstar2 infer.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to the output match-rate TSV file.",
+    )
+    parser.add_argument(
+        "--ploidy",
+        type=positive_int,
+        default=2,
+        help="Ploidy used to normalize dosage differences.",
+    )
+    parser.set_defaults(runner=_run_match)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -1,0 +1,405 @@
+# Copyright 2026 Xin Huang and Andrea Koca
+#
+# GNU General Public License v3.0
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, please see
+#
+#    https://www.gnu.org/licenses/gpl-3.0.en.html
+
+import argparse
+
+import allel
+import numpy as np
+import pandas as pd
+import pytest
+
+from sstar.match import (
+    _base_sample_name,
+    _dosage_for_positions,
+    _resolve_chrom,
+    calc_match_pct,
+    match,
+    run_match,
+)
+from sstar.parsers.match_parser import add_match_parser
+
+
+def _write_match_input_files(tmp_path, tract_text):
+    vcf_file = tmp_path / "mini.vcf"
+    tgt_ind_file = tmp_path / "tgt.ind.list"
+    src_ind_file = tmp_path / "src.ind.list"
+    tract_file = tmp_path / "tract.bed"
+    output_file = tmp_path / "nested" / "match.tsv"
+
+    vcf_file.write_text(
+        "##fileformat=VCFv4.2\n"
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n'
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tind1\tsrc1\tsrc2\n"
+        "21\t100\t.\tA\tG\t.\tPASS\t.\tGT\t0|0\t0|0\t1|1\n"
+        "21\t200\t.\tA\tG\t.\tPASS\t.\tGT\t0|1\t1|1\t0|1\n"
+        "21\t300\t.\tA\tG\t.\tPASS\t.\tGT\t1|1\t1|1\t.|.\n"
+    )
+    tgt_ind_file.write_text("ind1\n")
+    src_ind_file.write_text("src1\nsrc2\n")
+    tract_file.write_text(tract_text)
+
+    return vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file
+
+
+def test_calc_match_pct():
+    assert calc_match_pct([0, 1, 2], [0, 1, 2], P=2) == 1.0
+    assert calc_match_pct([0], [1], P=2) == 0.5
+    assert calc_match_pct([0], [2], P=2) == 0.0
+    assert calc_match_pct([0, 1, 2], [0, 2, 2], P=2) == pytest.approx(
+        (1.0 + 0.5 + 1.0) / 3
+    )
+    assert calc_match_pct([0, -1], [0, 2], P=2) == 1.0
+    assert calc_match_pct([-1], [-1], P=2) == "NA"
+    assert calc_match_pct([], [], P=2) == "NA"
+
+def test_dosage_for_positions():
+    gt = allel.GenotypeArray(
+        np.array(
+            [
+                [[0, 0]],
+                [[0, 1]],
+                [[1, 1]],
+                [[-1, -1]],
+            ]
+        )
+    )
+    pos = np.array([100, 200, 300, 400])
+
+    dosage = _dosage_for_positions(
+        gt=gt,
+        pos=pos,
+        ind_index=0,
+        positions=[300, 100, 250, 400, 200],
+    )
+
+    np.testing.assert_array_equal(dosage, np.array([2.0, 0.0, -1.0, -1.0, 1.0]))
+
+
+def test_dosage_for_positions_extracts_target_haplotype():
+    gt = allel.GenotypeArray(
+        np.array(
+            [
+                [[0, 1]],
+                [[1, 0]],
+                [[-1, -1]],
+            ]
+        )
+    )
+    pos = np.array([100, 200, 300])
+
+    np.testing.assert_array_equal(
+        _dosage_for_positions(gt, pos, 0, [100, 200, 300], hap_index=0, P=2),
+        np.array([0.0, 2.0, -1.0]),
+    )
+    np.testing.assert_array_equal(
+        _dosage_for_positions(gt, pos, 0, [100, 200, 300], hap_index=1, P=2),
+        np.array([2.0, 0.0, -1.0]),
+    )
+
+
+def test_match():
+    tgt_gt = allel.GenotypeArray(
+        np.array(
+            [
+                [[0, 0]],
+                [[0, 1]],
+                [[1, 1]],
+            ]
+        )
+    )
+    src_gt = allel.GenotypeArray(
+        np.array(
+            [
+                [[0, 0]],
+                [[1, 1]],
+                [[1, 1]],
+            ]
+        )
+    )
+    pos = np.array([100, 200, 300])
+
+    assert match(tgt_gt, pos, 0, src_gt, pos, 0, [100, 200, 300], P=2) == pytest.approx(
+        (1.0 + 0.5 + 1.0) / 3
+    )
+
+
+def test_match_uses_target_haplotype():
+    tgt_gt = allel.GenotypeArray(
+        np.array(
+            [
+                [[0, 1]],
+                [[1, 0]],
+            ]
+        )
+    )
+    src_gt = allel.GenotypeArray(
+        np.array(
+            [
+                [[0, 0]],
+                [[1, 1]],
+            ]
+        )
+    )
+    pos = np.array([100, 200])
+
+    assert (
+        match(
+            tgt_gt,
+            pos,
+            0,
+            src_gt,
+            pos,
+            0,
+            [100, 200],
+            P=2,
+            tgt_hap_index=0,
+        )
+        == 1.0
+    )
+    assert (
+        match(
+            tgt_gt,
+            pos,
+            0,
+            src_gt,
+            pos,
+            0,
+            [100, 200],
+            P=2,
+            tgt_hap_index=1,
+        )
+        == 0.0
+    )
+
+
+def test_base_sample_name_maps_phased_labels():
+    samples = ["ind1", "ind2"]
+
+    assert _base_sample_name("ind1", samples) == ("ind1", None)
+    assert _base_sample_name("ind1_1", samples) == ("ind1", 0)
+    assert _base_sample_name("ind1_2", samples) == ("ind1", 1)
+
+    with pytest.raises(ValueError):
+        _base_sample_name("missing_1", samples)
+
+
+def test_resolve_chrom_handles_chr_prefix():
+    data = {"21": {}, "chr22": {}}
+
+    assert _resolve_chrom("21", data) == "21"
+    assert _resolve_chrom("chr21", data) == "21"
+    assert _resolve_chrom("22", data) == "chr22"
+
+    with pytest.raises(ValueError):
+        _resolve_chrom("23", data)
+
+
+def test_run_match(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path, "21\t0\t250\tind1_1\n"
+    )
+
+    run_match(
+        vcf_file=str(vcf_file),
+        tgt_ind_file=str(tgt_ind_file),
+        src_ind_file=str(src_ind_file),
+        tract_file=str(tract_file),
+        output_file=str(output_file),
+        ploidy=2,
+    )
+
+    df = pd.read_csv(output_file, sep="\t")
+    assert df.columns.tolist() == [
+        "chrom",
+        "start",
+        "end",
+        "sample",
+        "match_rate",
+        "src_sample",
+    ]
+    assert df["sample"].tolist() == ["ind1_1", "ind1_1"]
+
+    rates = dict(zip(df["src_sample"], df["match_rate"]))
+    assert rates["src1"] == pytest.approx(0.5)
+    assert rates["src2"] == pytest.approx(0.25)
+
+
+def test_run_match_unphased_sample(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path, "21\t0\t250\tind1\n"
+    )
+
+    run_match(
+        vcf_file=str(vcf_file),
+        tgt_ind_file=str(tgt_ind_file),
+        src_ind_file=str(src_ind_file),
+        tract_file=str(tract_file),
+        output_file=str(output_file),
+        ploidy=2,
+    )
+
+    df = pd.read_csv(output_file, sep="\t")
+    assert df.columns.tolist() == [
+        "chrom",
+        "start",
+        "end",
+        "sample",
+        "match_rate",
+        "src_sample",
+    ]
+    assert df["sample"].tolist() == ["ind1", "ind1"]
+
+    rates = dict(zip(df["src_sample"], df["match_rate"]))
+    assert rates["src1"] == pytest.approx(0.75)
+    assert rates["src2"] == pytest.approx(0.5)
+
+
+def test_run_match_preserves_both_haplotype_labels(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path,
+        "21\t0\t250\tind1_1\n"
+        "21\t0\t250\tind1_2\n",
+    )
+
+    run_match(
+        vcf_file=str(vcf_file),
+        tgt_ind_file=str(tgt_ind_file),
+        src_ind_file=str(src_ind_file),
+        tract_file=str(tract_file),
+        output_file=str(output_file),
+        ploidy=2,
+    )
+
+    df = pd.read_csv(output_file, sep="\t")
+    assert set(df["sample"]) == {"ind1_1", "ind1_2"}
+
+    src1_rates = {
+        row["sample"]: row["match_rate"]
+        for _, row in df[df["src_sample"] == "src1"].iterrows()
+    }
+    assert src1_rates["ind1_1"] == pytest.approx(0.5)
+    assert src1_rates["ind1_2"] == pytest.approx(1.0)
+    assert src1_rates["ind1_1"] != src1_rates["ind1_2"]
+
+
+def test_run_match_ignores_extra_tract_columns(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path, "21\t0\t250\tind1_1\textra_value\n"
+    )
+
+    run_match(
+        vcf_file=str(vcf_file),
+        tgt_ind_file=str(tgt_ind_file),
+        src_ind_file=str(src_ind_file),
+        tract_file=str(tract_file),
+        output_file=str(output_file),
+        ploidy=2,
+    )
+
+    df = pd.read_csv(output_file, sep="\t")
+    assert df.columns.tolist() == [
+        "chrom",
+        "start",
+        "end",
+        "sample",
+        "match_rate",
+        "src_sample",
+    ]
+    assert df["sample"].tolist() == ["ind1_1", "ind1_1"]
+
+
+def test_run_match_rejects_malformed_tract_file(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path, "21\t0\t250\n"
+    )
+
+    with pytest.raises(
+        ValueError, match="tract file must contain at least four columns"
+    ):
+        run_match(
+            vcf_file=str(vcf_file),
+            tgt_ind_file=str(tgt_ind_file),
+            src_ind_file=str(src_ind_file),
+            tract_file=str(tract_file),
+            output_file=str(output_file),
+            ploidy=2,
+        )
+
+
+def test_run_match_writes_na_when_no_overlapping_positions(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path, "21\t400\t500\tind1_1\n"
+    )
+
+    run_match(
+        vcf_file=str(vcf_file),
+        tgt_ind_file=str(tgt_ind_file),
+        src_ind_file=str(src_ind_file),
+        tract_file=str(tract_file),
+        output_file=str(output_file),
+        ploidy=2,
+    )
+
+    df = pd.read_csv(output_file, sep="\t", keep_default_na=False)
+    assert df["sample"].tolist() == ["ind1_1", "ind1_1"]
+    assert df["src_sample"].tolist() == ["src1", "src2"]
+    assert df["match_rate"].tolist() == ["NA", "NA"]
+
+
+def test_match_parser_accepts_required_args(tmp_path):
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
+        tmp_path, "21\t0\t250\tind1_1\n"
+    )
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subparsers")
+    add_match_parser(subparsers)
+
+    args = parser.parse_args(
+        [
+            "match",
+            "--vcf",
+            str(vcf_file),
+            "--tgt",
+            str(tgt_ind_file),
+            "--src",
+            str(src_ind_file),
+            "--tract-file",
+            str(tract_file),
+            "--output",
+            str(output_file),
+        ]
+    )
+
+    assert args.vcf == str(vcf_file)
+    assert args.tgt == str(tgt_ind_file)
+    assert args.src == str(src_ind_file)
+    assert args.tract_file == str(tract_file)
+    assert args.output == str(output_file)
+    assert args.ploidy == 2
+    assert hasattr(args, "runner")
+    assert callable(args.runner)
+
+
+def test_match_parser_rejects_missing_required_args():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subparsers")
+    add_match_parser(subparsers)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["match"])    


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI subcommand to compute dosage-based match rates between target tracts and source individuals and write the results to a TSV output file.

New Features:
- Introduce genotype dosage-based match-rate computation utilities for pairs of individuals and genomic positions.
- Add a run_match workflow to compute tract-level match rates between target and source samples from VCF and BED-like tract inputs.
- Expose a new `match` subcommand in the sstar CLI to run the match-rate workflow from the command line.