### PR TITLE
Add configurable quantile start (`--quantile-start`) for quantile calculations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ And it should return some paths similar to
 
 Users can also use [Apptainer](https://apptainer.org/) to pull a container image that includes `sstar` and `ms`:
 
-    apptainer pull sstar.sif oras://ghcr.io/xin-huang/sstar:1.2.0
+    apptainer pull sstar.sif oras://ghcr.io/xin-huang/sstar:1.2.1
 
 Then run `sstar` with:
 

--- a/docs/userguide/quantile.md
+++ b/docs/userguide/quantile.md
@@ -61,7 +61,8 @@ The meaning of each column:
 | `--seq-len` | Length of the simulated sequence. |
 | `--snp-num-range` | Minimum SNP count, maximum SNP count, and step size used for `ms` simulations. |
 | `--output-dir` | Path to the output directory. |
-| `--quantile-step` | Step size between quantiles from 0.5 to less than 1. Default: `0.005`. |
+| `--quantile-step` | Step size between quantiles from `--quantile-start` to less than 1. Default: `0.005`. |
+| `--quantile-start` | First quantile to calculate. Default: `0.5`. |
 | `--thread` | Number of threads for multiprocessing. Default: `1`. |
 | `--keep-simulated-data` | Keep intermediate simulation directories instead of deleting them after summarizing results. |
 | `--phased` | Run `sstar score` on phased haplotypes during simulation scoring. |

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -12,12 +12,17 @@ theme:
     accent: cyan
 plugins:
   - search
+  - mike:
+      alias_type: redirect
 markdown_extensions:
   - extra
   - tables
   - fenced_code
   - admonition
   - codehilite
+extra:
+  version:
+    provider: mike
 extra_javascript:
   - 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML'
 nav:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sstar"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Python package for detecting archaic introgression from population genetic data with S*"
 readme = "README.md"
 requires-python = "==3.8.19"

--- a/sstar/__main__.py
+++ b/sstar/__main__.py
@@ -86,6 +86,7 @@ def _run_quantile(args: argparse.Namespace) -> None:
         is_phased=args.phased,
         keep_simulated_data=args.keep_simulated_data,
         quantile_step=args.quantile_step,
+        quantile_start=args.quantile_start,
     )
 
 
@@ -503,9 +504,16 @@ def _s_star_cli_parser() -> argparse.ArgumentParser:
         dest="quantile_step",
         default=0.005,
         help=(
-            "Step size between quantiles from 0.5 to less than 1. "
+            "Step size between quantiles from --quantile-start to less than 1. "
             "Default: %(default)s."
         ),
+    )
+    parser.add_argument(
+        "--quantile-start",
+        type=float,
+        dest="quantile_start",
+        default=0.5,
+        help="First quantile to calculate. Default: %(default)s.",
     )
     parser.add_argument(
         "--thread",

--- a/sstar/get_quantile.py
+++ b/sstar/get_quantile.py
@@ -93,6 +93,7 @@ def get_quantile(
     quantile_step: float,
     is_phased: bool = False,
     keep_simulated_data: bool = False,
+    quantile_start: float = 0.5,
 ) -> None:
     """
     Calculate quantiles of expected S* scores from ms simulations.
@@ -132,13 +133,18 @@ def get_quantile(
     seeds : list or None
         Three random seed numbers used in ms simulation. If None, ms uses its default seeding behavior.
     quantile_step : float
-        Step size between quantiles from 0.5 to less than 1.
+        Step size between quantiles from `quantile_start` to less than 1.
     is_phased : bool, optional
         If True, run `sstar score` with `--phased`. Default: `False`.
     keep_simulated_data : bool, optional
         If True, keep intermediate simulation directories. Default: `False`.
+    quantile_start : float, optional
+        First quantile to calculate. Must be greater than or equal to 0 and
+        less than 1. Quantiles are computed as
+        `np.arange(quantile_start, 1, quantile_step)`. Default: 0.5.
     """
     _validate_quantile_step(quantile_step)
+    _validate_quantile_start(quantile_start)
     if seeds is not None:
         np.random.seed(np.sum(seeds))
     output_dir = os.path.abspath(output_dir)
@@ -161,11 +167,27 @@ def get_quantile(
         thread,
         seeds,
         quantile_step,
-        is_phased,
+        is_phased=is_phased,
+        quantile_start=quantile_start,
     )
     _summary(output_dir, rec_rate)
     if not keep_simulated_data:
         _cleanup_simulated_data(output_dir, simulated_snp_dirs)
+
+
+def _validate_quantile_start(quantile_start: float) -> None:
+    """
+    Validate the first quantile to calculate.
+
+    Parameters
+    ----------
+    quantile_start : float
+        First quantile to calculate.
+    """
+    if not np.isfinite(quantile_start) or quantile_start < 0 or quantile_start >= 1:
+        raise ValueError(
+            "quantile_start must be greater than or equal to 0 and less than 1"
+        )
 
 
 def _validate_quantile_step(quantile_step: float) -> None:
@@ -175,7 +197,7 @@ def _validate_quantile_step(quantile_step: float) -> None:
     Parameters
     ----------
     quantile_step : float
-        Step size between quantiles from 0.5 to less than 1.
+        Step size between quantiles.
     """
     if not np.isfinite(quantile_step) or quantile_step <= 0 or quantile_step >= 0.5:
         raise ValueError("quantile_step must be greater than 0 and less than 0.5")
@@ -261,6 +283,7 @@ def _run_ms_simulation(
     seeds: Optional[list],
     quantile_step: float,
     is_phased: bool = False,
+    quantile_start: float = 0.5,
 ) -> list:
     """
     Run ms simulations across the requested SNP-count range.
@@ -296,9 +319,11 @@ def _run_ms_simulation(
     seeds : list or None
         Three random seed numbers used in ms simulation. If None, ms uses its default seeding behavior.
     quantile_step : float
-        Step size between quantiles from 0.5 to less than 1.
+        Step size between quantiles from `quantile_start` to less than 1.
     is_phased : bool, optional
         If True, run `sstar score` with `--phased`. Default: `False`.
+    quantile_start : float, optional
+        First quantile to calculate. Default: 0.5.
 
     Returns
     -------
@@ -369,6 +394,7 @@ def _run_ms_simulation(
                 seeds,
                 quantile_step,
                 is_phased,
+                quantile_start,
             ),
         )
         for _ii in range(thread)
@@ -406,6 +432,7 @@ def _run_ms_simulation_worker(
     seeds: Optional[list],
     quantile_step: float,
     is_phased: bool = False,
+    quantile_start: float = 0.5,
 ) -> None:
     """
     Worker process for running ms simulations and score quantile calculation.
@@ -437,9 +464,11 @@ def _run_ms_simulation_worker(
     seeds : list or None
         Three random seed numbers used in ms simulation. If None, ms uses its default seeding behavior.
     quantile_step : float
-        Step size between quantiles from 0.5 to less than 1.
+        Step size between quantiles from `quantile_start` to less than 1.
     is_phased : bool, optional
         If True, run `sstar score` with `--phased`. Default: `False`.
+    quantile_start : float, optional
+        First quantile to calculate. Default: 0.5.
     """
     while True:
         snp_num = in_queue.get()
@@ -526,7 +555,13 @@ def _run_ms_simulation_worker(
 
         _safe_sstar_score(score_cmd)  # safe wrapper (no linter error)
 
-        _cal_quantile(output_score, output_quantile, snp_num, quantile_step)
+        _cal_quantile(
+            output_score,
+            output_quantile,
+            snp_num,
+            quantile_step,
+            quantile_start=quantile_start,
+        )
         out_queue.put("Finished")
 
 
@@ -591,7 +626,11 @@ def _ms2vcf(
 
 
 def _cal_quantile(
-    in_file: str, out_file: str, snp_num: int, quantile_step: float
+    in_file: str,
+    out_file: str,
+    snp_num: int,
+    quantile_step: float,
+    quantile_start: float = 0.5,
 ) -> None:
     """
     Calculate quantiles of expected S* for one simulated SNP count.
@@ -605,9 +644,12 @@ def _cal_quantile(
     snp_num : int
         SNP count used in the ms simulation.
     quantile_step : float
-        Step size between quantiles from 0.5 to less than 1.
+        Step size between quantiles from `quantile_start` to less than 1.
+    quantile_start : float, optional
+        First quantile to calculate. Default: 0.5.
     """
     _validate_quantile_step(quantile_step)
+    _validate_quantile_start(quantile_start)
     df = pd.read_csv(in_file, sep="\t")
     df["S*_score"] = pd.to_numeric(df["S*_score"], errors="coerce")
     df = df.dropna(subset=["S*_score"])
@@ -615,7 +657,7 @@ def _cal_quantile(
     if df.empty:
         raise RuntimeError(f"No valid S* scores found in {in_file}")
 
-    quantiles = np.arange(0.5, 1, quantile_step)
+    quantiles = np.arange(quantile_start, 1, quantile_step)
     mean_df = (
         df.groupby(["chrom", "start", "end"], as_index=False)["S*_score"]
         .mean()

--- a/tests/test_get_quantile.py
+++ b/tests/test_get_quantile.py
@@ -134,6 +134,33 @@ def test_cal_quantile_basic(tmp_path):
     assert np.isclose(out["quantile"].max(), 0.995)
 
 
+def test_cal_quantile_custom_start(tmp_path):
+    in_file = tmp_path / "scores.txt"
+    out_file = tmp_path / "quantile.txt"
+
+    df = pd.DataFrame(
+        {
+            "chrom": ["1", "1", "1", "1"],
+            "start": [0, 0, 100, 100],
+            "end": [100, 100, 200, 200],
+            "S*_score": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    df.to_csv(in_file, sep="\t", index=False)
+
+    _cal_quantile(
+        str(in_file),
+        str(out_file),
+        snp_num=42,
+        quantile_step=0.01,
+        quantile_start=0.8,
+    )
+    out = pd.read_csv(out_file, sep="\t")
+
+    assert np.isclose(out["quantile"].min(), 0.8)
+    assert np.isclose(out["quantile"].max(), 0.99)
+
+
 def test_cal_quantile_custom_step(tmp_path):
     in_file = tmp_path / "scores.txt"
     out_file = tmp_path / "quantile.txt"
@@ -156,6 +183,25 @@ def test_cal_quantile_custom_step(tmp_path):
 
 
 @pytest.mark.parametrize(
+    "quantile_start",
+    [-0.1, 1.0, float("inf"), float("nan")],
+)
+def test_cal_quantile_rejects_invalid_start(tmp_path, quantile_start):
+    in_file = tmp_path / "scores.txt"
+    out_file = tmp_path / "quantile.txt"
+    in_file.write_text("chrom\tstart\tend\tS*_score\n1\t0\t1\t1.0\n")
+
+    with pytest.raises(ValueError):
+        _cal_quantile(
+            str(in_file),
+            str(out_file),
+            snp_num=42,
+            quantile_step=0.005,
+            quantile_start=quantile_start,
+        )
+
+
+@pytest.mark.parametrize(
     "quantile_step",
     [0, -0.1, 0.5, 1.0, float("inf"), float("nan")],
 )
@@ -165,7 +211,9 @@ def test_cal_quantile_rejects_invalid_step(tmp_path, quantile_step):
     in_file.write_text("chrom\tstart\tend\tS*_score\n1\t0\t1\t1.0\n")
 
     with pytest.raises(ValueError):
-        _cal_quantile(str(in_file), str(out_file), snp_num=42, quantile_step=quantile_step)
+        _cal_quantile(
+            str(in_file), str(out_file), snp_num=42, quantile_step=quantile_step
+        )
 
 
 def test_summary_aggregates_quantiles(tmp_path):

--- a/tests/test_main_.py
+++ b/tests/test_main_.py
@@ -99,6 +99,51 @@ def test_quantile_subcommand_calls_runner():
         args = mock_run.call_args[0][0]
         assert args.keep_simulated_data is False
         assert args.quantile_step == 0.005
+        assert args.quantile_start == 0.5
+
+
+def test_quantile_subcommand_quantile_start():
+    with patch("sstar.__main__._run_quantile") as mock_run:
+        main(
+            [
+                "quantile",
+                "--model",
+                "model.yaml",
+                "--ms-dir",
+                "/tmp/ms",
+                "--N0",
+                "10000",
+                "--nsamp",
+                "20",
+                "--nreps",
+                "10",
+                "--ref-pop",
+                "Western",
+                "--ref-size",
+                "10",
+                "--tgt-pop",
+                "Bonobo",
+                "--tgt-size",
+                "10",
+                "--mut-rate",
+                "1e-8",
+                "--rec-rate",
+                "1e-8",
+                "--seq-len",
+                "100000",
+                "--snp-num-range",
+                "50",
+                "200",
+                "10",
+                "--output-dir",
+                "quant_out",
+                "--quantile-start",
+                "0.8",
+            ]
+        )
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args.quantile_start == 0.8
 
 
 def test_quantile_subcommand_quantile_step():


### PR DESCRIPTION
### Motivation
- Allow users to specify the first quantile to calculate instead of hardcoding the start at 0.5 so quantile ranges can be customized for different analysis needs. 
- Surface the option through the CLI and ensure inputs are validated to prevent invalid quantile ranges. 

### Description
- Added a new CLI argument `--quantile-start` in `sstar.__main__` and threaded it through to `get_quantile`, the ms worker, and `_cal_quantile`. 
- Implemented `_validate_quantile_start` and updated `_validate_quantile_step` to validate the new parameter and existing step parameter. 
- Updated `_cal_quantile` to accept `quantile_start` and generate quantiles with `np.arange(quantile_start, 1, quantile_step)`. 
- Updated documentation `docs/userguide/quantile.md` and expanded unit tests in `tests/test_get_quantile.py` and `tests/test_main_.py` to cover custom starts and invalid values. 

### Testing
- Ran the test suite with `pytest`, including new tests `test_cal_quantile_custom_start` and `test_cal_quantile_rejects_invalid_start`, and all tests passed. 
- Existing quantile-related tests such as `test_cal_quantile_basic` and CLI parsing tests in `tests/test_main_.py` were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d1ab478c832ca47594b9b7348426)

## Summary by Sourcery

Add support for configuring the starting quantile for S* quantile calculations and expose it via the CLI.

New Features:
- Introduce a configurable quantile_start parameter for quantile calculations, defaulting to 0.5 and threaded through the simulation and quantile computation pipeline.
- Add a --quantile-start CLI option to control the first quantile computed by the quantile subcommand.

Enhancements:
- Relax docstrings and help text to describe quantile_step as operating from the configured starting quantile instead of always 0.5.
- Add validation for quantile_start to ensure it is finite and within [0, 1), alongside existing quantile_step validation.

Documentation:
- Update the quantile user guide to document the new --quantile-start option and the relationship between quantile_start and quantile_step.

Tests:
- Extend unit tests for quantile calculation and CLI parsing to cover custom quantile_start values and to assert rejection of invalid quantile_start inputs.