### PR TITLE
Docs: point example/test links to `v1` branch in user guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Then users can install `sstar` with `pip`.
 
 	pip install sstar
 
-Users can also use [mamba](https://github.com/mamba-org/mamba) to create a virtual environment and install `sstar` with this [build-env.yaml](https://github.com/xin-huang/sstar/blob/main/build-env.yaml).
+Users can also use [mamba](https://github.com/mamba-org/mamba) to create a virtual environment and install `sstar` with this [build-env.yaml](https://github.com/xin-huang/sstar/blob/v1/build-env.yaml).
 
 	mamba env create -f build-env.yaml
 	conda activate sstar

--- a/docs/userguide/matchrate.md
+++ b/docs/userguide/matchrate.md
@@ -2,7 +2,7 @@
 
 ### Input
 
-To calculate source match rates, users should provide a VCF file containing **phased** genotypes from the reference, target, and source populations (e.g. [test.match.rate.data.vcf](https://github.com/xin-huang/sstar/blob/main/tests/data/test.match.rate.data.vcf)). Users also need to provide three files containing names of individuals from the reference, target and source populations (e.g. [ref.ind.list](https://github.com/xin-huang/sstar/blob/main/examples/data/ind_list/ref.ind.list), [tgt.ind.list](https://github.com/xin-huang/sstar/blob/main/examples/data/ind_list/tgt.ind.list) and [nean.ind.list](https://github.com/xin-huang/sstar/blob/main/examples/data/ind_list/nean.ind.list)) for analysis. The file (e.g. [test.match.rate.score.exp.results.tsv](https://github.com/xin-huang/sstar/blob/main/tests/results/test.match.rate.score.exp.results.tsv)) containing S* scores from `sstar score` is also required.
+To calculate source match rates, users should provide a VCF file containing **phased** genotypes from the reference, target, and source populations (e.g. [test.match.rate.data.vcf](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.match.rate.data.vcf)). Users also need to provide three files containing names of individuals from the reference, target and source populations (e.g. [ref.ind.list](https://github.com/xin-huang/sstar/blob/v1/examples/data/ind_list/ref.ind.list), [tgt.ind.list](https://github.com/xin-huang/sstar/blob/v1/examples/data/ind_list/tgt.ind.list) and [nean.ind.list](https://github.com/xin-huang/sstar/blob/v1/examples/data/ind_list/nean.ind.list)) for analysis. The file (e.g. [test.match.rate.score.exp.results.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.match.rate.score.exp.results.tsv)) containing S* scores from `sstar score` is also required.
 
 Users can calculate source match rates with the following command:
 
@@ -13,7 +13,7 @@ Users can calculate source match rates with the following command:
                     --score tests/results/test.match.rate.score.exp.results.tsv \
                     --output test.match.rate.results.tsv
 
-The expected result above can be found in [test.match.rate.score.exp.results.tsv](https://github.com/xin-huang/sstar/blob/main/tests/results/test.match.rate.score.exp.results.tsv).
+The expected result above can be found in [test.match.rate.score.exp.results.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.match.rate.score.exp.results.tsv).
 
 ### Output
 

--- a/docs/userguide/overview.md
+++ b/docs/userguide/overview.md
@@ -20,4 +20,7 @@ For example:
 
 **Note:** In this manual, we define the population without introgressed fragments as the **reference population**, the population receiving introgressed fragments as the **target population**, and the population donating introgressed fragments as the **source population**.
 
-The example commands assume that users have cloned the `sstar` [GitHub repository](https://github.com/xin-huang/sstar) and run the commands from the root directory of the repository.
+The example commands assume that users have cloned the `sstar` [GitHub repository](https://github.com/xin-huang/sstar) and run the commands from the root directory of the repository:
+
+	git clone https://github.com/xin-huang/sstar -b v1 sstar-v1
+	cd sstar-v1

--- a/docs/userguide/quantile.md
+++ b/docs/userguide/quantile.md
@@ -4,7 +4,7 @@
 
 ### Input
 
-Users need to install the `ms` program from [Hudson Lab](https://home.uchicago.edu/~rhudson1/source/mksamples.html) and provide a demographic model (e.g., [BonoboGhost_4K19_no_introgression.yaml](https://github.com/xin-huang/sstar/blob/main/examples/models/BonoboGhost_4K19_no_introgression.yaml)) in [Demes](https://popsim-consortium.github.io/demes-spec-docs/main/introduction.html) YAML format. The reference sample size should match the number of chromosomes in the real data to be analyzed, whereas the target sample size should be `2`, because `sstar` predicts introgressed fragments for each target sample separately. Then users can use the following command:
+Users need to install the `ms` program from [Hudson Lab](https://home.uchicago.edu/~rhudson1/source/mksamples.html) and provide a demographic model (e.g., [BonoboGhost_4K19_no_introgression.yaml](https://github.com/xin-huang/sstar/blob/v1/examples/models/BonoboGhost_4K19_no_introgression.yaml)) in [Demes](https://popsim-consortium.github.io/demes-spec-docs/main/introduction.html) YAML format. The reference sample size should match the number of chromosomes in the real data to be analyzed, whereas the target sample size should be `2`, because `sstar` predicts introgressed fragments for each target sample separately. Then users can use the following command:
 
 	sstar quantile --model examples/models/BonoboGhost_4K19_no_introgression.yaml \
                    --ms-dir ext/msdir/ \
@@ -23,7 +23,7 @@ Users need to install the `ms` program from [Hudson Lab](https://home.uchicago.e
                    --thread 2 \
                    --seeds 1 2 3
 
-The expected result above can be found in [test.quantile.exp.summary](https://github.com/xin-huang/sstar/blob/main/tests/results/test.quantile.exp.summary).
+The expected result above can be found in [test.quantile.exp.summary](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.quantile.exp.summary).
 
 If users run `sstar` from [the Apptainer image](https://github.com/xin-huang/sstar/pkgs/container/sstar), `ms` is available at `/opt/ms`.
 

--- a/docs/userguide/score.md
+++ b/docs/userguide/score.md
@@ -2,7 +2,7 @@
 
 ### Input
 
-To calculate S* scores, users should provide a VCF file containing genotypes from the reference and target populations (e.g. [test.score.data.vcf](https://github.com/xin-huang/sstar/blob/main/tests/data/test.score.data.vcf)). The genotypes in the VCF file should be segregating in the combined reference and target populations used for scoring, and should not contain non-variable sites across these individuals. If additional individuals are included in the VCF file, such as potential source individuals used in later analyses, sites that are variable only in those additional individuals should not be included. Users also need to provide two files containing names of individuals from the reference and target populations (e.g. [test.ref.ind.list](https://github.com/xin-huang/sstar/blob/main/tests/data/test.ref.ind.list) and [test.tgt.ind.list](https://github.com/xin-huang/sstar/blob/main/tests/data/test.tgt.ind.list)) for analysis.
+To calculate S* scores, users should provide a VCF file containing genotypes from the reference and target populations (e.g. [test.score.data.vcf](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.score.data.vcf)). The genotypes in the VCF file should be segregating in the combined reference and target populations used for scoring, and should not contain non-variable sites across these individuals. If additional individuals are included in the VCF file, such as potential source individuals used in later analyses, sites that are variable only in those additional individuals should not be included. Users also need to provide two files containing names of individuals from the reference and target populations (e.g. [test.ref.ind.list](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.ref.ind.list) and [test.tgt.ind.list](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.tgt.ind.list)) for analysis.
 
 Users can calculate S* scores for unphased data with the following command:
 
@@ -11,7 +11,7 @@ Users can calculate S* scores for unphased data with the following command:
                 --tgt tests/data/test.tgt.ind.list \
                 --output test.score.unphased.results.tsv
 
-The expected result above can be found in [test.score.unphased.exp.results.tsv](https://github.com/xin-huang/sstar/blob/main/tests/results/test.score.unphased.exp.results.tsv).
+The expected result above can be found in [test.score.unphased.exp.results.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.score.unphased.exp.results.tsv).
 
 To calculate S* scores for phased data, add the --phased argument to the command:
 
@@ -21,7 +21,7 @@ To calculate S* scores for phased data, add the --phased argument to the command
                 --output test.score.phased.results.tsv \
                 --phased
 
-The expected result can be found in [test.score.phased.exp.results.tsv](https://github.com/xin-huang/sstar/blob/main/tests/results/test.score.phased.exp.results.tsv).
+The expected result can be found in [test.score.phased.exp.results.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.score.phased.exp.results.tsv).
 
 ### Output
 
@@ -59,4 +59,4 @@ The meaning of each column:
 | `--thread` | Number of CPUs used for multiprocessing. Default: `1`. |
 | `--phased` | Calculate scores on phased haplotypes instead of genotype dosages. |
 
-By default, `sstar` assumes the reference allele is the ancestral allele and the alternative allele is the derived allele. Users can use the argument `--anc-allele` with a BED format file (e.g. [test.anc.allele.bed](https://github.com/xin-huang/sstar/blob/main/tests/data/test.anc.allele.bed)) to define the ancestral allele for each variant. If `--anc-allele` is used, variants without ancestral allele information will be removed.
+By default, `sstar` assumes the reference allele is the ancestral allele and the alternative allele is the derived allele. Users can use the argument `--anc-allele` with a BED format file (e.g. [test.anc.allele.bed](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.anc.allele.bed)) to define the ancestral allele for each variant. If `--anc-allele` is used, variants without ancestral allele information will be removed.

--- a/docs/userguide/threshold.md
+++ b/docs/userguide/threshold.md
@@ -2,9 +2,9 @@
 
 ### Input
 
-To determine the significance of S\* scores, users should use data from simulations (e.g., [gravel_asn_scale_60k.simulated.data](https://raw.githubusercontent.com/xin-huang/sstar/main/examples/data/simulated_data/gravel_asn_scale_60k.simulated.data)) for building a generalized additive model to predict the expected S\* score under a demographic model without introgression. This file can be created with the [quantile command](https://xin-huang.github.io/sstar/userguide/quantile/).
+To determine the significance of S\* scores, users should use data from simulations (e.g., [gravel_asn_scale_60k.simulated.data](https://raw.githubusercontent.com/xin-huang/sstar/v1/examples/data/simulated_data/gravel_asn_scale_60k.simulated.data)) for building a generalized additive model to predict the expected S\* score under a demographic model without introgression. This file can be created with the [quantile command](https://xin-huang.github.io/sstar/userguide/quantile/).
 
-Users also need to provide the file containing S\* scores estimated from real data (e.g., [test.score.unphased.exp.results.tsv](https://github.com/xin-huang/sstar/blob/main/tests/results/test.score.unphased.exp.results.tsv)). Users can use a BED-like file (e.g., [hum.windows.50k.10k.recomb.map](https://raw.githubusercontent.com/xin-huang/sstar/main/examples/data/real_data/hum.windows.50k.10k.recomb.map)) to specify local recombination rates across the genome. If a window is not found in the recombination map but is present in the output file from `sstar score`, this window will be ignored when calculating significant thresholds.
+Users also need to provide the file containing S\* scores estimated from real data (e.g., [test.score.unphased.exp.results.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.score.unphased.exp.results.tsv)). Users can use a BED-like file (e.g., [hum.windows.50k.10k.recomb.map](https://raw.githubusercontent.com/xin-huang/sstar/v1/examples/data/real_data/hum.windows.50k.10k.recomb.map)) to specify local recombination rates across the genome. If a window is not found in the recombination map but is present in the output file from `sstar score`, this window will be ignored when calculating significant thresholds.
 
 Users can estimate significant S\* score thresholds at quantile 0.99 with the following command:
 
@@ -14,7 +14,7 @@ Users can estimate significant S\* score thresholds at quantile 0.99 with the fo
                     --quantile 0.99 \
                     --output test.threshold.results.tsv
 
-The expected result above can be found in [test.threshold.exp.results.tsv](https://github.com/xin-huang/sstar/blob/main/tests/results/test.threshold.exp.results.tsv).
+The expected result above can be found in [test.threshold.exp.results.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/results/test.threshold.exp.results.tsv).
 
 ### Output
 

--- a/docs/userguide/tract.md
+++ b/docs/userguide/tract.md
@@ -2,7 +2,7 @@
 
 ### Input
 
-To obtain candidate introgressed fragments from `sstar`, users should provide the output (e.g. [test.tract.threshold.tsv](https://github.com/xin-huang/sstar/blob/main/tests/data/test.tract.threshold.tsv)) from `sstar threshold`. If no source genome is available, users can use the following command:
+To obtain candidate introgressed fragments from `sstar`, users should provide the output (e.g. [test.tract.threshold.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.tract.threshold.tsv)) from `sstar threshold`. If no source genome is available, users can use the following command:
 
 	sstar tract --threshold tests/data/test.tract.threshold.tsv --output-prefix test
 
@@ -12,7 +12,7 @@ If one source genome is available, users can calculate source match rates and ou
 	            --output-prefix test \
 				--match-rate tests/data/test.tract.src1.match.rate.tsv
 
-If source genomes from two different source populations are available, users can provide the output (e.g. [test.tract.src1.match.rate.tsv](https://github.com/xin-huang/sstar/blob/main/tests/data/test.tract.src1.match.rate.tsv) and [test.tract.src2.match.rate.tsv](https://github.com/xin-huang/sstar/blob/main/tests/data/test.tract.src2.match.rate.tsv)) from `sstar matchrate`, and use the following command:
+If source genomes from two different source populations are available, users can provide the output (e.g. [test.tract.src1.match.rate.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.tract.src1.match.rate.tsv) and [test.tract.src2.match.rate.tsv](https://github.com/xin-huang/sstar/blob/v1/tests/data/test.tract.src2.match.rate.tsv)) from `sstar matchrate`, and use the following command:
 
 	sstar tract --threshold tests/data/test.tract.threshold.tsv \
 	            --output-prefix test \


### PR DESCRIPTION
### Motivation

- Ensure documentation example links reference the stable `v1` branch instead of `main` so examples and test artifacts resolve to the released dataset and model files.
- Keep example file paths consistent across the user guide and installation instructions for reproducibility of examples and expected outputs.

### Description

- Updated example links in `docs/index.md` and multiple files under `docs/userguide/` to use the `v1` branch (replacing `/blob/main/` and raw `main` URLs with `/blob/v1/` or `/v1/`).
- Files modified include `docs/index.md`, `docs/userguide/matchrate.md`, `docs/userguide/quantile.md`, `docs/userguide/score.md`, `docs/userguide/threshold.md`, and `docs/userguide/tract.md` to point to `v1` examples, test data, and expected results.
- No source code or behavioral logic was changed; this is a documentation-only update affecting example and test file references.

### Testing

- No automated tests were run as part of this change because it is documentation-only.
- The update does not modify the codebase or test inputs, so the existing automated test suite is unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bc14bbe00832c8e2dc5911110cffa)

## Summary by Sourcery

Update documentation links to reference stable v1 artifacts for examples and test data.

Documentation:
- Point user guide example and test file links from the main branch to the v1 branch to ensure they reference released datasets, models, and expected results.
- Update installation instructions to reference the v1 build-env.yaml for environment setup consistency.