### PR TITLE
Window-normalize dosage match rate, aggregate source rates, and update tests

### DIFF
--- a/sstar/match.py
+++ b/sstar/match.py
@@ -30,12 +30,16 @@ from sstar.utils import parse_ind_file, read_geno_data
 def calc_match_pct(
     x: Union[float, list, np.ndarray],
     y: Union[float, list, np.ndarray],
+    denominator: int,
     P: int = 2,
 ) -> Union[float, str]:
     """
-    Calculate dosage-based match rate between two genotype dosage arrays.
+    Calculate window-normalized dosage match rate between two genotype arrays.
 
-    Missing values must be encoded as -1 and are ignored.
+    Missing values must be encoded as -1 and contribute zero to the numerator.
+    The denominator is the population-level number of variants in the window.
+    Callable sites are positions where both genotype arrays have dosage values
+    greater than or equal to zero.
 
     Parameters
     ----------
@@ -43,22 +47,30 @@ def calc_match_pct(
         ALT-allele dosage values for the first genotype vector.
     y : float, list, or numpy.ndarray
         ALT-allele dosage values for the second genotype vector.
+    denominator : int
+        Number of population-level variants in the window. Missing genotypes
+        are included in this count even though they do not contribute to the
+        numerator.
     P : int, optional
         Ploidy used to normalize dosage differences. Default: 2.
 
     Returns
     -------
     float or str
-        Mean match rate in [0, 1], or "NA" if there are no callable sites.
+        Window-normalized match rate in [0, 1], or "NA" if the window has no
+        variants. If the window has variants but no callable pairwise sites,
+        return 0.0.
     """
+    if denominator == 0:
+        return "NA"
+
     x = np.atleast_1d(np.asarray(x, dtype=float))
     y = np.atleast_1d(np.asarray(y, dtype=float))
 
     ok = (x >= 0) & (y >= 0)
-    if not np.any(ok):
-        return "NA"
+    score_sum = np.sum(1.0 - np.abs(x[ok] - y[ok]) / float(P))
 
-    return float(np.mean(1.0 - np.abs(x[ok] - y[ok]) / float(P)))
+    return float(score_sum / denominator)
 
 
 def _dosage_for_positions(
@@ -73,7 +85,9 @@ def _dosage_for_positions(
     Return ALT dosage for one individual at exact genomic positions.
 
     If a requested position is absent or the genotype is missing, the returned
-    dosage is -1.
+    dosage is -1. When extracting a single haplotype, called alleles are
+    multiplied by ``P`` so that haplotype allele states are represented on the
+    same dosage scale used for diploid genotypes.
 
     Parameters
     ----------
@@ -86,15 +100,17 @@ def _dosage_for_positions(
     positions : list
         Genomic positions to query.
     hap_index : int or None, optional
-        Haplotype index to extract for phased targets. When None, return
-        diploid ALT dosage using scikit-allel's to_n_alt().
+        Zero-based haplotype index to extract for phased targets. When None,
+        return diploid ALT dosage using scikit-allel's to_n_alt().
     P : int, optional
-        Ploidy multiplier for haploid allele extraction. Default: 2.
+        Ploidy multiplier for haploid allele extraction. Default: 2, which
+        maps haplotype allele 0 to dosage 0 and haplotype allele 1 to dosage 2.
 
     Returns
     -------
     numpy.ndarray
-        Dosage array aligned to positions.
+        Dosage array aligned to positions. Missing genotypes and absent
+        positions are encoded as -1.
     """
     pos = np.asarray(pos)
     gt_arr = np.asarray(gt)
@@ -139,11 +155,47 @@ def match(
     src_pos: Union[list, np.ndarray],
     src_index: int,
     positions: list,
+    denominator: int,
     P: int = 2,
     tgt_hap_index: Optional[int] = None,
 ) -> Union[float, str]:
     """
     Calculate pairwise match rate between one target and one source individual.
+
+    Target and source dosages are extracted at the requested positions, then
+    compared with ``calc_match_pct`` using the provided window-level
+    denominator. If ``tgt_hap_index`` is provided, the target dosage is derived
+    from that haplotype only.
+
+    Parameters
+    ----------
+    tgt_gt : allel.GenotypeArray
+        Target genotype array.
+    tgt_pos : list or numpy.ndarray
+        Variant positions corresponding to ``tgt_gt``.
+    tgt_index : int
+        Index of the target individual in ``tgt_gt``.
+    src_gt : allel.GenotypeArray
+        Source genotype array.
+    src_pos : list or numpy.ndarray
+        Variant positions corresponding to ``src_gt``.
+    src_index : int
+        Index of the source individual in ``src_gt``.
+    positions : list
+        Window-level variant positions to compare.
+    denominator : int
+        Number of population-level variants in the window.
+    P : int, optional
+        Ploidy used to normalize dosage differences. Default: 2.
+    tgt_hap_index : int or None, optional
+        Zero-based target haplotype index to compare. When None, compare the
+        target diploid genotype dosage.
+
+    Returns
+    -------
+    float or str
+        Window-normalized pairwise match rate, or "NA" if the denominator is
+        zero.
     """
     tgt_dos = _dosage_for_positions(
         tgt_gt,
@@ -161,12 +213,34 @@ def match(
         P=P,
     )
 
-    return calc_match_pct(tgt_dos, src_dos, P)
+    return calc_match_pct(tgt_dos, src_dos, denominator=denominator, P=P)
 
 
 def _base_sample_name(sample: str, samples: list[str]) -> tuple[str, Optional[int]]:
     """
     Resolve a target tract label to a base sample and optional haplotype index.
+
+    Labels that exactly match an entry in ``samples`` are treated as unphased
+    diploid samples. Labels ending in ``_1`` or ``_2`` are treated as phased
+    haplotype labels when the prefix matches a sample name.
+
+    Parameters
+    ----------
+    sample : str
+        Target tract sample label.
+    samples : list of str
+        Valid target sample names.
+
+    Returns
+    -------
+    tuple[str, int or None]
+        Base sample name and zero-based haplotype index. The haplotype index is
+        None for unphased diploid samples.
+
+    Raises
+    ------
+    ValueError
+        If ``sample`` cannot be resolved against ``samples``.
     """
     if sample in samples:
         return sample, None
@@ -181,6 +255,27 @@ def _base_sample_name(sample: str, samples: list[str]) -> tuple[str, Optional[in
 def _resolve_chrom(chrom: object, data: dict) -> str:
     """
     Resolve a BED chromosome label against VCF chromosome keys.
+
+    If the label is not found exactly, this function tries the corresponding
+    representation with or without a ``chr`` prefix.
+
+    Parameters
+    ----------
+    chrom : object
+        Chromosome label from the tract file.
+    data : dict
+        Genotype data keyed by chromosome label.
+
+    Returns
+    -------
+    str
+        Chromosome key present in ``data``.
+
+    Raises
+    ------
+    ValueError
+        If neither the exact label nor the alternate ``chr``-prefixed form is
+        present in ``data``.
     """
     chrom = str(chrom)
     if chrom in data:
@@ -210,7 +305,33 @@ def run_match(
     ploidy: int = 2,
 ) -> None:
     """
-    Calculate source match rates for inferred tracts and write them to a TSV.
+    Calculate aggregated source match rates for inferred tracts.
+
+    The tract file must contain at least four columns: chromosome, start, end,
+    and target sample label. Tract coordinates are interpreted as BED-style
+    0-based half-open intervals, so a 1-based VCF position belongs to a tract
+    when ``start < POS <= end``. Window variants are the union of target and
+    source VCF positions in the tract. For each source individual, the pairwise
+    score is normalized by this window-level variant count, and the final
+    tract score is the mean across all source individuals.
+
+    Parameters
+    ----------
+    vcf_file : str
+        Input VCF file containing target and source samples.
+    tgt_ind_file : str
+        File containing one target sample name per line.
+    src_ind_file : str
+        File containing one source sample name per line.
+    tract_file : str
+        BED-like tract file with at least chrom, start, end, and sample
+        columns. Additional columns are ignored.
+    output_file : str
+        Output TSV path. The output columns are chrom, start, end, sample, and
+        match_rate.
+    ploidy : int, optional
+        Ploidy used to normalize dosage differences and scale haplotype
+        dosages. Default: 2.
     """
     tgt_samples = parse_ind_file(tgt_ind_file)
     src_samples = parse_ind_file(src_ind_file)
@@ -249,8 +370,10 @@ def run_match(
         tgt_region_pos = tgt_pos[(tgt_pos > start) & (tgt_pos <= end)]
         src_region_pos = src_pos[(src_pos > start) & (src_pos <= end)]
         positions = np.union1d(tgt_region_pos, src_region_pos).astype(int).tolist()
+        window_variant_count = len(positions)
 
-        for src_index, src_sample in enumerate(src_samples):
+        source_rates = []
+        for src_index, _src_sample in enumerate(src_samples):
             rate = match(
                 tgt_gt=tgt_gt,
                 tgt_pos=tgt_pos,
@@ -259,23 +382,30 @@ def run_match(
                 src_pos=src_pos,
                 src_index=src_index,
                 positions=positions,
+                denominator=window_variant_count,
                 tgt_hap_index=tgt_hap_index,
                 P=ploidy,
             )
-            rows.append(
-                {
-                    "chrom": chrom,
-                    "start": start,
-                    "end": end,
-                    "sample": tract_sample,
-                    "match_rate": rate,
-                    "src_sample": src_sample,
-                }
-            )
+            source_rates.append(rate)
+
+        if window_variant_count == 0:
+            rate = "NA"
+        else:
+            rate = float(np.mean(source_rates))
+
+        rows.append(
+            {
+                "chrom": chrom,
+                "start": start,
+                "end": end,
+                "sample": tract_sample,
+                "match_rate": rate,
+            }
+        )
 
     output_dir = os.path.dirname(output_file)
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
 
-    columns = ["chrom", "start", "end", "sample", "match_rate", "src_sample"]
+    columns = ["chrom", "start", "end", "sample", "match_rate"]
     pd.DataFrame(rows, columns=columns).to_csv(output_file, sep="\t", index=False)

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -58,15 +58,16 @@ def _write_match_input_files(tmp_path, tract_text):
 
 
 def test_calc_match_pct():
-    assert calc_match_pct([0, 1, 2], [0, 1, 2], P=2) == 1.0
-    assert calc_match_pct([0], [1], P=2) == 0.5
-    assert calc_match_pct([0], [2], P=2) == 0.0
-    assert calc_match_pct([0, 1, 2], [0, 2, 2], P=2) == pytest.approx(
+    assert calc_match_pct([0, 1, 2], [0, 1, 2], denominator=3, P=2) == 1.0
+    assert calc_match_pct([0], [1], denominator=1, P=2) == 0.5
+    assert calc_match_pct([0], [2], denominator=1, P=2) == 0.0
+    assert calc_match_pct([0, 1, 2], [0, 2, 2], denominator=3, P=2) == pytest.approx(
         (1.0 + 0.5 + 1.0) / 3
     )
-    assert calc_match_pct([0, -1], [0, 2], P=2) == 1.0
-    assert calc_match_pct([-1], [-1], P=2) == "NA"
-    assert calc_match_pct([], [], P=2) == "NA"
+    assert calc_match_pct([0, -1], [0, 2], denominator=2, P=2) == 0.5
+    assert calc_match_pct([-1], [-1], denominator=1, P=2) == 0.0
+    assert calc_match_pct([], [], denominator=0, P=2) == "NA"
+
 
 def test_dosage_for_positions():
     gt = allel.GenotypeArray(
@@ -134,9 +135,9 @@ def test_match():
     )
     pos = np.array([100, 200, 300])
 
-    assert match(tgt_gt, pos, 0, src_gt, pos, 0, [100, 200, 300], P=2) == pytest.approx(
-        (1.0 + 0.5 + 1.0) / 3
-    )
+    assert match(
+        tgt_gt, pos, 0, src_gt, pos, 0, [100, 200, 300], denominator=3, P=2
+    ) == pytest.approx((1.0 + 0.5 + 1.0) / 3)
 
 
 def test_match_uses_target_haplotype():
@@ -167,6 +168,7 @@ def test_match_uses_target_haplotype():
             pos,
             0,
             [100, 200],
+            denominator=2,
             P=2,
             tgt_hap_index=0,
         )
@@ -181,6 +183,7 @@ def test_match_uses_target_haplotype():
             pos,
             0,
             [100, 200],
+            denominator=2,
             P=2,
             tgt_hap_index=1,
         )
@@ -211,8 +214,8 @@ def test_resolve_chrom_handles_chr_prefix():
 
 
 def test_run_match(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path, "21\t0\t250\tind1_1\n"
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(tmp_path, "21\t0\t250\tind1_1\n")
     )
 
     run_match(
@@ -225,24 +228,14 @@ def test_run_match(tmp_path):
     )
 
     df = pd.read_csv(output_file, sep="\t")
-    assert df.columns.tolist() == [
-        "chrom",
-        "start",
-        "end",
-        "sample",
-        "match_rate",
-        "src_sample",
-    ]
-    assert df["sample"].tolist() == ["ind1_1", "ind1_1"]
-
-    rates = dict(zip(df["src_sample"], df["match_rate"]))
-    assert rates["src1"] == pytest.approx(0.5)
-    assert rates["src2"] == pytest.approx(0.25)
+    assert df.columns.tolist() == ["chrom", "start", "end", "sample", "match_rate"]
+    assert df["sample"].tolist() == ["ind1_1"]
+    assert df["match_rate"].tolist() == pytest.approx([0.375])
 
 
 def test_run_match_unphased_sample(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path, "21\t0\t250\tind1\n"
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(tmp_path, "21\t0\t250\tind1\n")
     )
 
     run_match(
@@ -255,26 +248,17 @@ def test_run_match_unphased_sample(tmp_path):
     )
 
     df = pd.read_csv(output_file, sep="\t")
-    assert df.columns.tolist() == [
-        "chrom",
-        "start",
-        "end",
-        "sample",
-        "match_rate",
-        "src_sample",
-    ]
-    assert df["sample"].tolist() == ["ind1", "ind1"]
-
-    rates = dict(zip(df["src_sample"], df["match_rate"]))
-    assert rates["src1"] == pytest.approx(0.75)
-    assert rates["src2"] == pytest.approx(0.5)
+    assert df.columns.tolist() == ["chrom", "start", "end", "sample", "match_rate"]
+    assert df["sample"].tolist() == ["ind1"]
+    assert df["match_rate"].tolist() == pytest.approx([0.625])
 
 
 def test_run_match_preserves_both_haplotype_labels(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path,
-        "21\t0\t250\tind1_1\n"
-        "21\t0\t250\tind1_2\n",
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(
+            tmp_path,
+            "21\t0\t250\tind1_1\n" "21\t0\t250\tind1_2\n",
+        )
     )
 
     run_match(
@@ -289,18 +273,15 @@ def test_run_match_preserves_both_haplotype_labels(tmp_path):
     df = pd.read_csv(output_file, sep="\t")
     assert set(df["sample"]) == {"ind1_1", "ind1_2"}
 
-    src1_rates = {
-        row["sample"]: row["match_rate"]
-        for _, row in df[df["src_sample"] == "src1"].iterrows()
-    }
-    assert src1_rates["ind1_1"] == pytest.approx(0.5)
-    assert src1_rates["ind1_2"] == pytest.approx(1.0)
-    assert src1_rates["ind1_1"] != src1_rates["ind1_2"]
+    rates = {row["sample"]: row["match_rate"] for _, row in df.iterrows()}
+    assert rates["ind1_1"] == pytest.approx(0.375)
+    assert rates["ind1_2"] == pytest.approx(0.625)
+    assert rates["ind1_1"] != rates["ind1_2"]
 
 
 def test_run_match_ignores_extra_tract_columns(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path, "21\t0\t250\tind1_1\textra_value\n"
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(tmp_path, "21\t0\t250\tind1_1\textra_value\n")
     )
 
     run_match(
@@ -313,20 +294,13 @@ def test_run_match_ignores_extra_tract_columns(tmp_path):
     )
 
     df = pd.read_csv(output_file, sep="\t")
-    assert df.columns.tolist() == [
-        "chrom",
-        "start",
-        "end",
-        "sample",
-        "match_rate",
-        "src_sample",
-    ]
-    assert df["sample"].tolist() == ["ind1_1", "ind1_1"]
+    assert df.columns.tolist() == ["chrom", "start", "end", "sample", "match_rate"]
+    assert df["sample"].tolist() == ["ind1_1"]
 
 
 def test_run_match_rejects_malformed_tract_file(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path, "21\t0\t250\n"
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(tmp_path, "21\t0\t250\n")
     )
 
     with pytest.raises(
@@ -343,8 +317,8 @@ def test_run_match_rejects_malformed_tract_file(tmp_path):
 
 
 def test_run_match_writes_na_when_no_overlapping_positions(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path, "21\t400\t500\tind1_1\n"
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(tmp_path, "21\t400\t500\tind1_1\n")
     )
 
     run_match(
@@ -357,14 +331,13 @@ def test_run_match_writes_na_when_no_overlapping_positions(tmp_path):
     )
 
     df = pd.read_csv(output_file, sep="\t", keep_default_na=False)
-    assert df["sample"].tolist() == ["ind1_1", "ind1_1"]
-    assert df["src_sample"].tolist() == ["src1", "src2"]
-    assert df["match_rate"].tolist() == ["NA", "NA"]
+    assert df["sample"].tolist() == ["ind1_1"]
+    assert df["match_rate"].tolist() == ["NA"]
 
 
 def test_match_parser_accepts_required_args(tmp_path):
-    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = _write_match_input_files(
-        tmp_path, "21\t0\t250\tind1_1\n"
+    vcf_file, tgt_ind_file, src_ind_file, tract_file, output_file = (
+        _write_match_input_files(tmp_path, "21\t0\t250\tind1_1\n")
     )
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="subparsers")
@@ -402,4 +375,4 @@ def test_match_parser_rejects_missing_required_args():
     add_match_parser(subparsers)
 
     with pytest.raises(SystemExit):
-        parser.parse_args(["match"])    
+        parser.parse_args(["match"])


### PR DESCRIPTION
### Motivation

- Ensure match scores reflect the full window variant count (population-level denominator) rather than only callable sites, and simplify output by reporting a single per-tract match rate.

### Description

- Change `calc_match_pct` to accept a `denominator` and return `"NA"` when the denominator is zero, computing the numerator over callable sites but dividing by the provided window variant count.
- Thread `denominator` through `match` and compute `window_variant_count = len(positions)` in `run_match` so each tract is normalized by the number of variants in the window.
- Aggregate per-source match rates into a single per-tract average `match_rate` and remove the `src_sample` column from output, writing one row per tract.
- Update unit tests in `tests/test_match.py` to reflect the new denominator semantics and aggregated output format and adjust expected numeric values accordingly.

### Testing

- Ran the match tests with `pytest tests/test_match.py` after the changes; the updated test suite passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35373f8b38832c81369ecd664cee5d)

## Summary by Sourcery

Normalize dosage match rates by window-level variant counts and aggregate per-source match scores into a single per-tract match rate in the match pipeline.

Enhancements:
- Update calc_match_pct and match to use an explicit window-variant denominator and treat missing genotypes as zero contribution while still normalizing by the full window.
- Change run_match to compute window variant counts, average match rates across all sources per tract, and drop the src_sample column from the output.

Tests:
- Adjust match unit tests to cover the new denominator semantics, aggregated per-tract match rates, and the updated output schema without per-source rows.