### PR TITLE
Skip rows with missing S*_score in quantile regression inference and add unit test

### DIFF
--- a/sstar/quantile_regression.py
+++ b/sstar/quantile_regression.py
@@ -77,9 +77,10 @@ def infer(
     """
     Predict `S*_score` and export regions exceeding the predicted score.
 
-    Predictions are generated for rows with non-missing
-    `Region_ind_SNP_number`. Rows with missing feature values keep
-    `Predicted_S*_score` as `NA`. The full table is written to `output`.
+    Predictions are generated for rows with non-missing `S*_score` and
+    `Region_ind_SNP_number`. Rows with missing observed scores or feature
+    values keep `Predicted_S*_score` as `NA`. The full table is written to
+    `output`.
     Regions where observed `S*_score` is greater than `Predicted_S*_score`
     are written to `bed_file` in BED format. The BED start coordinate is
     converted from 1-based to 0-based by subtracting 1.
@@ -97,7 +98,7 @@ def infer(
         `S*_score` greater than `Predicted_S*_score`.
     """
     df = pd.read_csv(data, sep="\t")
-    mask = df["Region_ind_SNP_number"].notna()
+    mask = df["S*_score"].notna() & df["Region_ind_SNP_number"].notna()
     df["Predicted_S*_score"] = np.nan
     session_options = ort.SessionOptions()
     session_options.intra_op_num_threads = 1

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -20,6 +20,7 @@
 
 import pandas as pd
 from sstar.infer import infer
+from sstar.quantile_regression import infer as qr_infer
 
 
 def test_infer(tmp_path):
@@ -57,3 +58,33 @@ def test_infer(tmp_path):
             rtol=1e-6,
             atol=1e-8,
         )
+
+
+def test_quantile_regression_infer_skips_missing_sstar_score(tmp_path):
+    features_file = tmp_path / "features.tsv"
+    pred_file = tmp_path / "pred.tsv"
+    tract_file = tmp_path / "tracts.bed"
+
+    features = pd.DataFrame(
+        {
+            "Chromosome": ["21", "21"],
+            "Start": [1, 50001],
+            "End": [50000, 100000],
+            "Sample": ["ind1_1", "ind1_1"],
+            "S*_score": [pd.NA, 67770.0],
+            "Region_ind_SNP_number": [10, 10],
+        }
+    )
+    features.to_csv(features_file, sep="\t", index=False, na_rep="NA")
+
+    qr_infer(
+        data=features_file,
+        model="tests/data/test.qr.model.onnx",
+        output=pred_file,
+        bed_file=tract_file,
+    )
+
+    predictions = pd.read_csv(pred_file, sep="\t")
+
+    assert pd.isna(predictions.loc[0, "Predicted_S*_score"])
+    assert pd.notna(predictions.loc[1, "Predicted_S*_score"])


### PR DESCRIPTION
### Motivation
- Ensure the ONNX-based quantile regression inference does not attempt to predict for regions that lack an observed `S*_score`, avoiding spurious outputs or mismatched rows. 
- Add a unit test to lock in the intended behavior of skipping rows with missing `S*_score` while still predicting for rows with valid features.

### Description
- Updated `sstar/quantile_regression.py` `infer` to only run the model on rows where both `S*_score` and `Region_ind_SNP_number` are present by changing the mask to `df["S*_score"].notna() & df["Region_ind_SNP_number"].notna()` and adjusted the docstring accordingly. 
- Added a unit test `test_quantile_regression_infer_skips_missing_sstar_score` in `tests/test_infer.py` that writes a small features table with one missing `S*_score`, invokes `quantile_regression.infer` via `qr_infer`, and asserts that the corresponding `Predicted_S*_score` is `NA` while other rows are predicted.

### Testing
- Ran the infer tests in `tests/test_infer.py` including `test_quantile_regression_infer_skips_missing_sstar_score` via `pytest tests/test_infer.py -q` and the test passed. 
- Existing infer validation `test_infer` in `tests/test_infer.py` was also executed and passed, confirming no regressions to the original infer logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37af17cad0832c9d1d84b208218124)

## Summary by Sourcery

Ensure quantile regression inference skips rows without observed S*_score while preserving existing behavior for valid rows.

Bug Fixes:
- Prevent quantile regression inference from generating predictions for rows missing S*_score by requiring both S*_score and Region_ind_SNP_number to be present.

Tests:
- Add a regression test verifying quantile regression inference leaves Predicted_S*_score as NA for rows with missing S*_score while predicting for rows with complete data.