### PR TITLE
Append `.inferred.tracts.bed` suffix to assign outputs and update docs/tests

### DIFF
--- a/docs/userguide/assign.md
+++ b/docs/userguide/assign.md
@@ -22,7 +22,7 @@ This generates two BED files: [one](https://github.com/xin-huang/sstar/blob/main
 One BED file is written for each source name:
 
 ```text
-<output-prefix>.<source-name>.bed
+<output-prefix>.<source-name>.inferred.tracts.bed
 ```
 
 Each output file is tab-separated and has no header:

--- a/sstar/assign.py
+++ b/sstar/assign.py
@@ -168,6 +168,6 @@ def assign_source_by_match_rate(
         os.makedirs(output_dir, exist_ok=True)
 
     for source_name in source_names:
-        output_file = f"{output_prefix}.{source_name}.bed"
+        output_file = f"{output_prefix}.{source_name}.inferred.tracts.bed"
         rows = merged.loc[assigned_sources == source_name, KEY_COLUMNS + [source_name]]
         rows.to_csv(output_file, sep="\t", header=False, index=False)

--- a/tests/test_assign.py
+++ b/tests/test_assign.py
@@ -71,12 +71,12 @@ def test_assign_source_by_unique_maximum_match_rate(tmp_path):
         output_prefix=str(output_prefix),
     )
 
-    src1_bed = _read_bed(tmp_path / "out.src1.bed")
-    src2_bed = _read_bed(tmp_path / "out.src2.bed")
+    src1_bed = _read_bed(tmp_path / "out.src1.inferred.tracts.bed")
+    src2_bed = _read_bed(tmp_path / "out.src2.inferred.tracts.bed")
 
     assert src1_bed.values.tolist() == [[1, 100, 200, "ind1", 0.8]]
     assert src2_bed.values.tolist() == [[1, 300, 400, "ind1", 0.9]]
-    assert (tmp_path / "out.src3.bed").read_text() == ""
+    assert (tmp_path / "out.src3.inferred.tracts.bed").read_text() == ""
 
 
 def test_assign_source_uses_intersection_of_tract_keys(tmp_path):
@@ -105,9 +105,9 @@ def test_assign_source_uses_intersection_of_tract_keys(tmp_path):
         output_prefix=str(output_prefix),
     )
 
-    src1_bed = _read_bed(tmp_path / "out.src1.bed")
+    src1_bed = _read_bed(tmp_path / "out.src1.inferred.tracts.bed")
     assert src1_bed.values.tolist() == [[1, 100, 200, "ind1", 0.8]]
-    assert (tmp_path / "out.src2.bed").read_text() == ""
+    assert (tmp_path / "out.src2.inferred.tracts.bed").read_text() == ""
 
 
 def test_assign_source_ignores_na_and_rejects_ties(tmp_path):
@@ -147,10 +147,10 @@ def test_assign_source_ignores_na_and_rejects_ties(tmp_path):
         output_prefix=str(output_prefix),
     )
 
-    src2_bed = _read_bed(tmp_path / "out.src2.bed")
+    src2_bed = _read_bed(tmp_path / "out.src2.inferred.tracts.bed")
     assert src2_bed.values.tolist() == [[1, 100, 200, "ind1", 0.4]]
-    assert (tmp_path / "out.src1.bed").read_text() == ""
-    assert (tmp_path / "out.src3.bed").read_text() == ""
+    assert (tmp_path / "out.src1.inferred.tracts.bed").read_text() == ""
+    assert (tmp_path / "out.src3.inferred.tracts.bed").read_text() == ""
 
 
 def test_assign_source_validates_inputs(tmp_path):


### PR DESCRIPTION
### Motivation

- Make the output filenames for the `assign` command more descriptive by indicating they contain inferred tracts. 

### Description

- Change the output filename pattern in `sstar.assign` from `<output-prefix>.<source-name>.bed` to `<output-prefix>.<source-name>.inferred.tracts.bed`. 
- Update the user guide (`docs/userguide/assign.md`) to document the new output filename. 
- Update unit tests (`tests/test_assign.py`) to expect the new filenames. 

### Testing

- Ran the updated unit tests in `tests/test_assign.py` with `pytest tests/test_assign.py` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37b91f9d84832c9af71ca913f9fbfd)

## Summary by Sourcery

Update assign output filenames to indicate inferred tracts and align docs and tests with the new naming convention.

Enhancements:
- Rename assign output BED files to include an `.inferred.tracts.bed` suffix for clarity.

Documentation:
- Document the new `.inferred.tracts.bed` output filename pattern in the assign user guide.

Tests:
- Adjust assign command tests to expect the new `.inferred.tracts.bed` output filenames.