### PR TITLE
Fix wording in sstar2 manual

### DIFF
--- a/docs/userguide/infer.md
+++ b/docs/userguide/infer.md
@@ -16,7 +16,7 @@ sstar2 infer --model examples/results/sstar2.example.trained.model.onnx \
              --tract-file examples/results/sstar2.example.inferred.tracts.bed
 ```
 
-The inferred tracts can be found [here](https://github.com/xin-huang/sstar/blob/main/examples/results/sstar2.example.inferred.tracts.bed). Two files are also generated: [one](https://github.com/xin-huang/sstar/blob/main/examples/results/sstar2.example.inference.features.tsv) records the features for prediction, and [the other](https://github.com/xin-huang/sstar/blob/main/examples/results/sstar2.example.pred.tsv) contains the observed and predicted *S*\* scores.
+The inferred tracts can be found [here](https://github.com/xin-huang/sstar/blob/main/examples/results/sstar2.example.inferred.tracts.bed). Two additional files are generated: [one](https://github.com/xin-huang/sstar/blob/main/examples/results/sstar2.example.inference.features.tsv) records the features for prediction, and [the other](https://github.com/xin-huang/sstar/blob/main/examples/results/sstar2.example.pred.tsv) contains the observed and predicted *S*\* scores.
 
 ### Outputs
 

--- a/docs/userguide/overview.md
+++ b/docs/userguide/overview.md
@@ -12,7 +12,7 @@ There are four subcommands in `sstar2`:
 To display help information for each subcommand, users can use:
 
 ```
-sstar2 subcommand -h
+sstar2 <subcommand> -h
 ```
 
 For example:
@@ -21,7 +21,7 @@ For example:
 sstar2 train -h
 ```
 
-If you need further help, such as such as reporting a bug or suggesting a feature, please open an [issue](https://github.com/xin-huang/sstar/issues).
+If you need further help, such as reporting a bug or suggesting a feature, please open an [issue](https://github.com/xin-huang/sstar/issues).
 
 **Note:** In this manual, we define the population without introgressed fragments as the **reference population**, the population receiving introgressed fragments as the **target population**, and the population donating introgressed fragments as the **source population**.
 


### PR DESCRIPTION
## Summary by Sourcery

Clarify wording in the sstar2 user guide to improve help command examples and output description.

Documentation:
- Update overview documentation to show the generic help command syntax using angle brackets and fix a repeated phrase in the support guidance.
- Refine infer command documentation to more clearly describe the two additional output files produced during tract inference.