### PR TITLE
Fix phased match-rate sample handling

### DIFF
--- a/sstar/cal_match_rate.py
+++ b/sstar/cal_match_rate.py
@@ -325,8 +325,17 @@ def _cal_tgt_match_pct_manager(
     ]
 
     for t in samples:
-        index = tgt_samples.index(t)
-        in_queue.put((index, data[t]))
+        if phased:
+            sample_base, haplotype = t.rsplit("_", 1)
+            if haplotype not in {"1", "2"}:
+                raise ValueError(f"Invalid phased sample label: {t}")
+            haplotype_index = int(haplotype) - 1
+        else:
+            sample_base = t
+            haplotype_index = None
+
+        index = tgt_samples.index(sample_base)
+        in_queue.put((index, haplotype_index, data[t]))
 
     try:
         for worker in workers:
@@ -390,7 +399,7 @@ def _cal_tgt_match_pct_worker(
     """
 
     while True:
-        index, data = in_queue.get()
+        index, haplotype_index, data = in_queue.get()
         res = _cal_match_pct_ind(
             data,
             index,
@@ -399,7 +408,8 @@ def _cal_tgt_match_pct_worker(
             src_data,
             src_samples,
             sample_size,
-            phased,  # NEW
+            haplotype_index,
+            phased,
             score_col,
         )
         out_queue.put("\n".join(res))
@@ -414,7 +424,8 @@ def _cal_match_pct_ind(
     src_data: dict,
     src_samples: list,
     sample_size: int,
-    phased: bool,  # NEW
+    haplotype_index: Optional[int],
+    phased: bool,
     score_col: dict,
 ) -> list:
     """
@@ -462,45 +473,54 @@ def _cal_match_pct_ind(
         for src_ind_index in range(len(src_samples)):
             src_sample = src_samples[src_ind_index]
 
-            hap1_res = cal_matchpct(
-                chr_name,
-                mapped_intervals,
-                tgt_data,
-                src_data,
-                tgt_ind_index,
-                src_ind_index,
-                0,
-                int(win_start),
-                int(win_end),
-                sample_size,
-            )
-            hap2_res = cal_matchpct(
-                chr_name,
-                mapped_intervals,
-                tgt_data,
-                src_data,
-                tgt_ind_index,
-                src_ind_index,
-                1,
-                int(win_start),
-                int(win_end),
-                sample_size,
-            )
-
-            hap1_match_pct = hap1_res[-1]
-            hap2_match_pct = hap2_res[-1]
-            hap_match_pct = "NA"
-            if (hap1_match_pct != "NA") and (hap2_match_pct != "NA"):
-                hap_match_pct = (hap1_match_pct + hap2_match_pct) / 2
-
             if phased:
-                res.append(
-                    f"{chr_name}\t{win_start}\t{win_end}\t{sample}_1\t{hap1_match_pct}\t{src_sample}"
+                hap_res = cal_matchpct(
+                    chr_name,
+                    mapped_intervals,
+                    tgt_data,
+                    src_data,
+                    tgt_ind_index,
+                    src_ind_index,
+                    haplotype_index,
+                    int(win_start),
+                    int(win_end),
+                    sample_size,
                 )
                 res.append(
-                    f"{chr_name}\t{win_start}\t{win_end}\t{sample}_2\t{hap2_match_pct}\t{src_sample}"
+                    f"{chr_name}\t{win_start}\t{win_end}\t{sample}\t{hap_res[-1]}\t{src_sample}"
                 )
             else:
+                hap1_res = cal_matchpct(
+                    chr_name,
+                    mapped_intervals,
+                    tgt_data,
+                    src_data,
+                    tgt_ind_index,
+                    src_ind_index,
+                    0,
+                    int(win_start),
+                    int(win_end),
+                    sample_size,
+                )
+                hap2_res = cal_matchpct(
+                    chr_name,
+                    mapped_intervals,
+                    tgt_data,
+                    src_data,
+                    tgt_ind_index,
+                    src_ind_index,
+                    1,
+                    int(win_start),
+                    int(win_end),
+                    sample_size,
+                )
+
+                hap1_match_pct = hap1_res[-1]
+                hap2_match_pct = hap2_res[-1]
+                hap_match_pct = "NA"
+                if (hap1_match_pct != "NA") and (hap2_match_pct != "NA"):
+                    hap_match_pct = (hap1_match_pct + hap2_match_pct) / 2
+
                 res.append(
                     f"{chr_name}\t{win_start}\t{win_end}\t{sample}\t{hap_match_pct}\t{src_sample}"
                 )

--- a/tests/test_cal_match_rate.py
+++ b/tests/test_cal_match_rate.py
@@ -96,9 +96,20 @@ def test_calc_match_pct_with_scikit_allel_genotypes():
 
 def test_cal_match_pct_phased_matches_golden(data, tmp_path):
     """
-    phased=True must match the existing golden file exactly.
+    phased=True must consume score rows whose sample labels already contain
+    haplotype suffixes such as sample_1 and sample_2.
     """
     out = tmp_path / "match_rate.phased.tsv"
+    phased_score_file = tmp_path / "score.phased.tsv"
+
+    score = pd.read_csv(data["score_file"], sep="\t", keep_default_na=False)
+    phased_score = score.loc[score.index.repeat(2)].reset_index(drop=True)
+    phased_score["sample"] = [
+        f"{sample}_{hap}"
+        for sample in score["sample"]
+        for hap in (1, 2)
+    ]
+    phased_score.to_csv(phased_score_file, sep="\t", index=False)
 
     cal_match_pct(
         data["vcf"],
@@ -108,13 +119,19 @@ def test_cal_match_pct_phased_matches_golden(data, tmp_path):
         None,
         str(out),
         1,
-        data["score_file"],
+        str(phased_score_file),
         None,
         phased=True,
     )
 
-    df = pd.read_csv(out, sep="\t")
-    df_expected = pd.read_csv(data["exp_output_phased"], sep="\t")
+    sort_cols = ["chrom", "start", "end", "sample", "src_sample"]
+
+    df = pd.read_csv(out, sep="\t").sort_values(sort_cols).reset_index(drop=True)
+    df_expected = (
+        pd.read_csv(data["exp_output_phased"], sep="\t")
+        .sort_values(sort_cols)
+        .reset_index(drop=True)
+    )
 
     pd.testing.assert_frame_equal(
         df,


### PR DESCRIPTION
## Summary by Sourcery

Handle phased match-rate calculation using per-haplotype score rows and ensure tests reflect haplotype-suffixed samples.

Bug Fixes:
- Correct phased match-rate handling by mapping haplotype-suffixed sample labels to their base target samples and passing haplotype indices through the worker pipeline.

Enhancements:
- Refine phased match-rate logic to operate on a single haplotype at a time while preserving unphased averaging behavior for combined haplotypes.

Tests:
- Update phased match-rate tests to construct haplotype-suffixed score inputs and compare sorted outputs against the expected phased results.